### PR TITLE
Delay node updates to end of server tick

### DIFF
--- a/changelogs/changelog-v0.4.2+1.19.3.md
+++ b/changelogs/changelog-v0.4.2+1.19.3.md
@@ -1,0 +1,8 @@
+# GraphLib v0.4.2+1.19.3
+
+GraphLib version 0.4.2 for Minecraft 1.19.3
+
+Changes:
+
+* Delays all node and connection updates until the end of the server tick to allow for update-deduplication and
+  lag-reduction.

--- a/src/main/java/com/kneelawk/graphlib/graph/simple/SimpleBlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/simple/SimpleBlockGraph.java
@@ -229,7 +229,7 @@ public class SimpleBlockGraph implements com.kneelawk.graphlib.graph.BlockGraph 
         nodesInPos.put(pos, graphNode);
         chunks.add(ChunkSectionPos.from(pos).asLong());
         controller.addGraphInPos(id, pos);
-        controller.scheduleUpdate(graphNode);
+        controller.scheduleCallbackUpdate(graphNode);
         return graphNode;
     }
 
@@ -243,9 +243,9 @@ public class SimpleBlockGraph implements com.kneelawk.graphlib.graph.BlockGraph 
         for (Link<BlockNodeHolder> link : node.connections()) {
             // scheduled updates happen after, so we don't need to worry whether the node's been removed from the graph
             // yet, as it will be when these updates are actually applied
-            controller.scheduleUpdate(link.other(node));
+            controller.scheduleCallbackUpdate(link.other(node));
         }
-        controller.scheduleUpdate(node);
+        controller.scheduleCallbackUpdate(node);
 
         // actually remove the node
         graph.remove(node);
@@ -285,14 +285,14 @@ public class SimpleBlockGraph implements com.kneelawk.graphlib.graph.BlockGraph 
 
     void link(@NotNull Node<BlockNodeHolder> a, @NotNull Node<BlockNodeHolder> b) {
         graph.link(a, b);
-        controller.scheduleUpdate(a);
-        controller.scheduleUpdate(b);
+        controller.scheduleCallbackUpdate(a);
+        controller.scheduleCallbackUpdate(b);
     }
 
     void unlink(@NotNull Node<BlockNodeHolder> a, @NotNull Node<BlockNodeHolder> b) {
         graph.unlink(a, b);
-        controller.scheduleUpdate(a);
-        controller.scheduleUpdate(b);
+        controller.scheduleCallbackUpdate(a);
+        controller.scheduleCallbackUpdate(b);
     }
 
     void merge(@NotNull SimpleBlockGraph other) {


### PR DESCRIPTION
# This PR
This PR delays all node and connection updates until the end of the server tick to allow for update-deduplication and lag-reduction.

# Testing
This has been tested on the 0.3.x branch in a single-player world where server tick lag is visible as a graph. This change had a notable impact on reducing server tick lag when bundled cables are moved using Create contraptions.