### PR TITLE
0.3.x-1.19 Add debug rendering for graph nodes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,10 @@ base {
     archivesName.set(archives_base_name)
 }
 
+loom {
+    accessWidenerPath.set(file("src/main/resources/graphlib.accesswidener"))
+}
+
 repositories {
     mavenCentral()
     maven("https://maven.quiltmc.org/repository/release") { name = "Quilt Releases" }

--- a/src/main/java/com/kneelawk/graphlib/GraphLib.java
+++ b/src/main/java/com/kneelawk/graphlib/GraphLib.java
@@ -7,6 +7,7 @@ import com.kneelawk.graphlib.graph.BlockNodeDecoder;
 import com.kneelawk.graphlib.graph.BlockNodeDiscoverer;
 import com.kneelawk.graphlib.graph.simple.SimpleBlockGraphController;
 import com.kneelawk.graphlib.mixin.api.StorageHelper;
+import com.kneelawk.graphlib.net.BlockNodePacketEncoderHolder;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.serialization.Lifecycle;
 import net.minecraft.server.command.ServerCommandSource;
@@ -31,14 +32,23 @@ import java.util.stream.Collectors;
 public final class GraphLib {
     private static final Identifier BLOCK_NODE_DECODER_IDENTIFIER = Constants.id("block_node_decoder");
     private static final RegistryKey<Registry<BlockNodeDecoder>> BLOCK_NODE_DECODER_KEY =
-            RegistryKey.ofRegistry(BLOCK_NODE_DECODER_IDENTIFIER);
+        RegistryKey.ofRegistry(BLOCK_NODE_DECODER_IDENTIFIER);
+    private static final Identifier BLOCK_NODE_PACKET_ENDODER_IDENTIFIER = Constants.id("block_node_packet_encoder");
+    private static final RegistryKey<Registry<BlockNodePacketEncoderHolder<?>>> BLOCK_NODE_PACKET_ENCODER_KEY =
+        RegistryKey.ofRegistry(BLOCK_NODE_PACKET_ENDODER_IDENTIFIER);
     private static final List<BlockNodeDiscoverer> BLOCK_NODE_DISCOVERERS = new ArrayList<>();
 
     /**
      * Registry of {@link BlockNodeDecoder}s for block-node type ids.
      */
     public static final Registry<BlockNodeDecoder> BLOCK_NODE_DECODER =
-            new SimpleRegistry<>(BLOCK_NODE_DECODER_KEY, Lifecycle.experimental(), null);
+        new SimpleRegistry<>(BLOCK_NODE_DECODER_KEY, Lifecycle.experimental(), null);
+
+    /**
+     * Registry of {@link BlockNodePacketEncoderHolder}s for encoding nodes to send to the client for debug rendering.
+     */
+    public static final Registry<BlockNodePacketEncoderHolder<?>> BLOCK_NODE_PACKET_ENCODER =
+        new SimpleRegistry<>(BLOCK_NODE_PACKET_ENCODER_KEY, Lifecycle.experimental(), null);
 
     /**
      * Registers a {@link BlockNodeDiscoverer} for use in detecting the nodes in a given block position.
@@ -62,7 +72,7 @@ public final class GraphLib {
      */
     public static @NotNull Set<BlockNode> getNodesInBlock(@NotNull ServerWorld world, @NotNull BlockPos pos) {
         return BLOCK_NODE_DISCOVERERS.stream().flatMap(discoverer -> discoverer.getNodesInBlock(world, pos).stream())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /**
@@ -87,7 +97,9 @@ public final class GraphLib {
     @SuppressWarnings("unchecked")
     static void register() {
         Registry.register((Registry<Registry<?>>) Registry.REGISTRIES, BLOCK_NODE_DECODER_IDENTIFIER,
-                BLOCK_NODE_DECODER);
+            BLOCK_NODE_DECODER);
+        Registry.register((Registry<Registry<?>>) Registry.REGISTRIES, BLOCK_NODE_PACKET_ENDODER_IDENTIFIER,
+            BLOCK_NODE_PACKET_ENCODER);
     }
 
     static void registerCommands(CommandDispatcher<ServerCommandSource> dispatcher) {

--- a/src/main/java/com/kneelawk/graphlib/GraphLibEvents.java
+++ b/src/main/java/com/kneelawk/graphlib/GraphLibEvents.java
@@ -1,0 +1,46 @@
+package com.kneelawk.graphlib;
+
+import com.kneelawk.graphlib.graph.BlockGraph;
+import com.kneelawk.graphlib.graph.BlockGraphController;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.server.world.ServerWorld;
+
+public final class GraphLibEvents {
+    private GraphLibEvents() {
+    }
+
+    public static final Event<GraphCreatedListener> GRAPH_CREATED =
+        EventFactory.createArrayBacked(GraphCreatedListener.class, (world, controller, graph) -> {
+        }, listeners -> (world, controller, graph) -> {
+            for (GraphCreatedListener listener : listeners) {
+                listener.graphCreated(world, controller, graph);
+            }
+        });
+
+    public static final Event<GraphUpdatedListener> GRAPH_UPDATED =
+        EventFactory.createArrayBacked(GraphUpdatedListener.class, (world, controller, graph) -> {
+        }, listeners -> (world, controller, graph) -> {
+            for (GraphUpdatedListener listener : listeners) {
+                listener.graphUpdated(world, controller, graph);
+            }
+        });
+
+    public static final Event<GraphDestroyedListener> GRAPH_DESTROYED = EventFactory.createArrayBacked(GraphDestroyedListener.class, (world, controller, id) -> {}, listeners -> (world, controller, id) -> {
+        for (GraphDestroyedListener listener : listeners) {
+            listener.graphDestroyed(world, controller, id);
+        }
+    });
+
+    public interface GraphCreatedListener {
+        void graphCreated(ServerWorld world, BlockGraphController controller, BlockGraph graph);
+    }
+
+    public interface GraphUpdatedListener {
+        void graphUpdated(ServerWorld world, BlockGraphController controller, BlockGraph graph);
+    }
+
+    public interface GraphDestroyedListener {
+        void graphDestroyed(ServerWorld world, BlockGraphController controller, long id);
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/GraphLibFabricMod.java
+++ b/src/main/java/com/kneelawk/graphlib/GraphLibFabricMod.java
@@ -1,6 +1,7 @@
 package com.kneelawk.graphlib;
 
 import com.kneelawk.graphlib.graph.simple.SimpleBlockGraphController;
+import com.kneelawk.graphlib.net.GraphLibCommonNetworking;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerChunkEvents;
@@ -15,6 +16,8 @@ public class GraphLibFabricMod implements ModInitializer {
         GLLog.setupLogging(FabricLoader.getInstance().getGameDir());
 
         GraphLib.register();
+
+        GraphLibCommonNetworking.init();
 
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> GraphLib.registerCommands(dispatcher));
 

--- a/src/main/java/com/kneelawk/graphlib/client/GraphLibClient.java
+++ b/src/main/java/com/kneelawk/graphlib/client/GraphLibClient.java
@@ -1,0 +1,85 @@
+package com.kneelawk.graphlib.client;
+
+import com.kneelawk.graphlib.Constants;
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.graph.SimpleClientBlockNode;
+import com.kneelawk.graphlib.client.graph.SimpleClientSidedBlockNode;
+import com.kneelawk.graphlib.client.render.BlockNodeRendererHolder;
+import com.kneelawk.graphlib.client.render.SimpleBlockNodeRenderer;
+import com.kneelawk.graphlib.client.render.SimpleSidedBlockNodeRenderer;
+import com.kneelawk.graphlib.net.BlockNodePacketDecoder;
+import com.mojang.serialization.Lifecycle;
+import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.util.registry.SimpleRegistry;
+
+import java.util.Set;
+
+/**
+ * Graph Lib Client-Side Public API. This class contains static methods and fields for registering
+ * {@link BlockNodePacketDecoder}s and renderers.
+ */
+public final class GraphLibClient {
+    private GraphLibClient() {
+    }
+
+    private static final Identifier BLOCK_NODE_PACKET_DECODER_ID = Constants.id("block_node_packet_decoder");
+    private static final RegistryKey<Registry<BlockNodePacketDecoder>> BLOCK_NODE_PACKET_DECODER_KEY =
+        RegistryKey.ofRegistry(BLOCK_NODE_PACKET_DECODER_ID);
+
+    private static final Identifier BLOCK_NODE_RENDERER_ID = Constants.id("block_node_renderer");
+    private static final RegistryKey<Registry<BlockNodeRendererHolder<?>>> BLOCK_NODE_RENDERER_KEY =
+        RegistryKey.ofRegistry(BLOCK_NODE_RENDERER_ID);
+
+    /**
+     * Registry for custom block node decoders.
+     */
+    public static final Registry<BlockNodePacketDecoder> BLOCK_NODE_PACKET_DECODER =
+        new SimpleRegistry<>(BLOCK_NODE_PACKET_DECODER_KEY, Lifecycle.experimental(), null);
+
+    /**
+     * Registry for custom block node renderers.
+     */
+    public static final Registry<BlockNodeRendererHolder<?>> BLOCK_NODE_RENDERER =
+        new SimpleRegistry<>(BLOCK_NODE_RENDERER_KEY, Lifecycle.experimental(), null);
+
+    /**
+     * Map of graph id long to graph for all currently debugging graphs.
+     */
+    public static final Long2ObjectMap<ClientBlockGraph> DEBUG_GRAPHS = new Long2ObjectLinkedOpenHashMap<>();
+
+    /**
+     * Map of {@link ChunkPos#toLong()} to a set of graphs in that chunk for all currently debugging graphs.
+     */
+    public static final Long2ObjectMap<Set<ClientBlockGraph>> GRAPHS_PER_CHUNK = new Long2ObjectLinkedOpenHashMap<>();
+
+    @SuppressWarnings("unchecked")
+    static void register() {
+        Registry.register((Registry<Registry<?>>) Registry.REGISTRIES, BLOCK_NODE_PACKET_DECODER_ID,
+            BLOCK_NODE_PACKET_DECODER);
+        Registry.register((Registry<Registry<?>>) Registry.REGISTRIES, BLOCK_NODE_RENDERER_ID,
+            BLOCK_NODE_RENDERER);
+
+        Registry.register(BLOCK_NODE_RENDERER, Constants.id("simple"),
+            new BlockNodeRendererHolder<>(SimpleClientBlockNode.class, SimpleBlockNodeRenderer.INSTANCE));
+        Registry.register(BLOCK_NODE_RENDERER, Constants.id("simple_sided"),
+            new BlockNodeRendererHolder<>(SimpleClientSidedBlockNode.class, SimpleSidedBlockNodeRenderer.INSTANCE));
+    }
+
+    static void removeGraphChunks(ClientBlockGraph graph) {
+        for (long graphChunk : graph.chunks()) {
+            Set<ClientBlockGraph> graphsAt = GraphLibClient.GRAPHS_PER_CHUNK.get(graphChunk);
+            if (graphsAt != null) {
+                graphsAt.remove(graph);
+
+                if (graphsAt.isEmpty()) {
+                    GraphLibClient.GRAPHS_PER_CHUNK.remove(graphChunk);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/GraphLibClientNetworking.java
+++ b/src/main/java/com/kneelawk/graphlib/client/GraphLibClientNetworking.java
@@ -1,0 +1,178 @@
+package com.kneelawk.graphlib.client;
+
+import com.kneelawk.graphlib.GLLog;
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.graph.ClientBlockNodeHolder;
+import com.kneelawk.graphlib.client.graph.SimpleClientBlockNode;
+import com.kneelawk.graphlib.client.graph.SimpleClientSidedBlockNode;
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import com.kneelawk.graphlib.graph.struct.Graph;
+import com.kneelawk.graphlib.graph.struct.Node;
+import com.kneelawk.graphlib.net.BlockNodePacketDecoder;
+import com.kneelawk.graphlib.net.GraphLibCommonNetworking;
+import it.unimi.dsi.fastutil.ints.Int2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.Direction;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public final class GraphLibClientNetworking {
+    private GraphLibClientNetworking() {
+    }
+
+    private static final Map<Integer, Identifier> idMap = Collections.synchronizedMap(new Int2ObjectLinkedOpenHashMap<>());
+
+    public static final BlockNodePacketDecoder DEFAULT_DECODER = buf -> {
+        int hashCode = buf.readInt();
+        int classHash = buf.readInt();
+
+        byte type = buf.readByte();
+
+        return switch (type) {
+            case 0 -> new SimpleClientBlockNode(hashCode, classHash);
+            case 1 -> new SimpleClientSidedBlockNode(hashCode, classHash, Direction.byId(buf.readByte()));
+            default -> {
+                GLLog.error("Attempted default BlockNode decoding but encountered unknown default id: {}", type);
+                yield null;
+            }
+        };
+    };
+
+    public static void init() {
+        ClientPlayNetworking.registerGlobalReceiver(GraphLibCommonNetworking.ID_MAP_BULK_ID,
+            (client, handler, buf, responseSender) -> {
+                int size = buf.readVarInt();
+
+                for (int i = 0; i < size; i++) {
+                    Identifier id = buf.readIdentifier();
+                    int index = buf.readVarInt();
+                    idMap.put(index, id);
+                }
+            });
+        ClientPlayNetworking.registerGlobalReceiver(GraphLibCommonNetworking.ID_MAP_PUT_ID,
+            (client, handler, buf, responseSender) -> {
+                Identifier id = buf.readIdentifier();
+                int index = buf.readVarInt();
+                idMap.put(index, id);
+            });
+
+        ClientPlayNetworking.registerGlobalReceiver(GraphLibCommonNetworking.GRAPH_UPDATE_ID,
+            (client, handler, buf, responseSender) -> {
+
+                ClientBlockGraph debugGraph = decodeBlockGraph(buf);
+                if (debugGraph == null) return;
+
+                client.execute(() -> addBlockGraph(debugGraph));
+            });
+        ClientPlayNetworking.registerGlobalReceiver(GraphLibCommonNetworking.GRAPH_UPDATE_BULK_ID,
+            (client, handler, buf, responseSender) -> {
+
+                int graphCount = buf.readVarInt();
+                List<ClientBlockGraph> graphs = new ArrayList<>(graphCount);
+
+                for (int i = 0; i < graphCount; i++) {
+                    ClientBlockGraph debugGraph = decodeBlockGraph(buf);
+                    if (debugGraph == null) return;
+                    graphs.add(debugGraph);
+                }
+
+                client.execute(() -> {
+                    for (ClientBlockGraph debugGraph : graphs) {
+                        addBlockGraph(debugGraph);
+                    }
+                });
+            });
+        ClientPlayNetworking.registerGlobalReceiver(GraphLibCommonNetworking.GRAPH_DESTROY_ID,
+            (client, handler, buf, responseSender) -> {
+                long graphId = buf.readLong();
+
+                client.execute(() -> {
+                    ClientBlockGraph graph = GraphLibClient.DEBUG_GRAPHS.remove(graphId);
+
+                    if (graph != null) {
+                        GraphLibClient.removeGraphChunks(graph);
+                    }
+                });
+            });
+        ClientPlayNetworking.registerGlobalReceiver(GraphLibCommonNetworking.DEBUGGING_STOP_ID,
+            (client, handler, buf, responseSender) -> client.execute(() -> {
+                GraphLibClient.DEBUG_GRAPHS.clear();
+                GraphLibClient.GRAPHS_PER_CHUNK.clear();
+            }));
+    }
+
+    @Nullable
+    private static ClientBlockGraph decodeBlockGraph(PacketByteBuf buf) {
+        Graph<ClientBlockNodeHolder> graph = new Graph<>();
+        List<Node<ClientBlockNodeHolder>> nodeList = new ArrayList<>();
+        LongSet chunks = new LongLinkedOpenHashSet();
+
+        long graphId = buf.readLong();
+
+        int nodeCount = buf.readVarInt();
+        for (int i = 0; i < nodeCount; i++) {
+            int nodeTypeInt = buf.readVarInt();
+            Identifier nodeTypeId = idMap.get(nodeTypeInt);
+            if (nodeTypeId == null) {
+                GLLog.error("Received unknown BlockNode id: {}", nodeTypeInt);
+                return null;
+            }
+
+            BlockPos pos = buf.readBlockPos();
+
+            BlockNodePacketDecoder decoder = GraphLibClient.BLOCK_NODE_PACKET_DECODER.get(nodeTypeId);
+            if (decoder == null) {
+                decoder = DEFAULT_DECODER;
+            }
+
+            ClientBlockNode data = decoder.fromPacket(buf);
+            if (data == null) {
+                GLLog.error("Unable to decode BlockNode packet for {}", nodeTypeId);
+                return null;
+            }
+
+            Node<ClientBlockNodeHolder> node = graph.add(new ClientBlockNodeHolder(pos, data, graphId));
+            nodeList.add(node);
+
+            chunks.add(ChunkPos.toLong(pos));
+        }
+
+        int linkCount = buf.readVarInt();
+        for (int i = 0; i < linkCount; i++) {
+            Node<ClientBlockNodeHolder> nodeA = nodeList.get(buf.readVarInt());
+            Node<ClientBlockNodeHolder> nodeB = nodeList.get(buf.readVarInt());
+
+            graph.link(nodeA, nodeB);
+        }
+
+        return new ClientBlockGraph(graphId, graph, chunks);
+    }
+
+    private static void addBlockGraph(ClientBlockGraph debugGraph) {
+        ClientBlockGraph oldGraph = GraphLibClient.DEBUG_GRAPHS.put(debugGraph.graphId(), debugGraph);
+
+        if (oldGraph != null) {
+            GraphLibClient.removeGraphChunks(oldGraph);
+        }
+
+        for (long chunk : debugGraph.chunks()) {
+            Set<ClientBlockGraph> chunkSet = GraphLibClient.GRAPHS_PER_CHUNK.get(chunk);
+            if (chunkSet == null) {
+                chunkSet = new LinkedHashSet<>();
+                chunkSet.add(debugGraph);
+                GraphLibClient.GRAPHS_PER_CHUNK.put(chunk, chunkSet);
+            } else {
+                chunkSet.add(debugGraph);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/GraphLibFabricModClient.java
+++ b/src/main/java/com/kneelawk/graphlib/client/GraphLibFabricModClient.java
@@ -1,0 +1,56 @@
+package com.kneelawk.graphlib.client;
+
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.render.DebugRenderer;
+import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientChunkEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public class GraphLibFabricModClient implements ClientModInitializer {
+    private final LongSet loadedChunks = new LongLinkedOpenHashSet();
+
+    /**
+     * Runs the mod initializer on the client environment.
+     */
+    @Override
+    public void onInitializeClient() {
+        GraphLibClient.register();
+
+        GraphLibClientNetworking.init();
+
+        DebugRenderer.init();
+
+        ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> GraphLibClient.DEBUG_GRAPHS.clear());
+        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> GraphLibClient.DEBUG_GRAPHS.clear());
+
+        ClientChunkEvents.CHUNK_LOAD.register((world, chunk) -> loadedChunks.add(chunk.getPos().toLong()));
+        ClientChunkEvents.CHUNK_UNLOAD.register((world, chunk) -> {
+            long chunkLong = chunk.getPos().toLong();
+            loadedChunks.remove(chunkLong);
+
+            Set<ClientBlockGraph> graphs = GraphLibClient.GRAPHS_PER_CHUNK.get(chunkLong);
+            if (graphs != null) {
+                for (ClientBlockGraph graph : graphs) {
+                    boolean anyChunkLoaded = false;
+                    for (long graphChunk : graph.chunks()) {
+                        if (loadedChunks.contains(graphChunk)) {
+                            anyChunkLoaded = true;
+                            break;
+                        }
+                    }
+
+                    if (!anyChunkLoaded) {
+                        GraphLibClient.DEBUG_GRAPHS.remove(graph.graphId());
+
+                        GraphLibClient.removeGraphChunks(graph);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/graph/ClientBlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/client/graph/ClientBlockGraph.java
@@ -1,0 +1,8 @@
+package com.kneelawk.graphlib.client.graph;
+
+import com.kneelawk.graphlib.graph.struct.Graph;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import org.jetbrains.annotations.NotNull;
+
+public record ClientBlockGraph(long graphId, @NotNull Graph<ClientBlockNodeHolder> graph, @NotNull LongSet chunks) {
+}

--- a/src/main/java/com/kneelawk/graphlib/client/graph/ClientBlockNodeHolder.java
+++ b/src/main/java/com/kneelawk/graphlib/client/graph/ClientBlockNodeHolder.java
@@ -1,0 +1,15 @@
+package com.kneelawk.graphlib.client.graph;
+
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import net.minecraft.util.math.BlockPos;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Holds a {@link ClientBlockNode} along with its {@link BlockPos}.
+ *
+ * @param pos     the block position of the node.
+ * @param node    the node itself.
+ * @param graphId the id of the graph this node belongs to.
+ */
+public record ClientBlockNodeHolder(@NotNull BlockPos pos, @NotNull ClientBlockNode node, long graphId) {
+}

--- a/src/main/java/com/kneelawk/graphlib/client/graph/SimpleClientBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/client/graph/SimpleClientBlockNode.java
@@ -1,0 +1,19 @@
+package com.kneelawk.graphlib.client.graph;
+
+import com.kneelawk.graphlib.Constants;
+import com.kneelawk.graphlib.client.GraphLibClient;
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+public record SimpleClientBlockNode(int hash, int classHash) implements ClientBlockNode {
+    /**
+     * Gets the id of the renderer registered with {@link GraphLibClient#BLOCK_NODE_RENDERER}.
+     *
+     * @return the id of the renderer to use to render this block node.
+     */
+    @Override
+    public @NotNull Identifier getRenderId() {
+        return Constants.id("simple");
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/graph/SimpleClientSidedBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/client/graph/SimpleClientSidedBlockNode.java
@@ -1,0 +1,21 @@
+package com.kneelawk.graphlib.client.graph;
+
+import com.kneelawk.graphlib.Constants;
+import com.kneelawk.graphlib.client.GraphLibClient;
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import com.kneelawk.graphlib.graph.SidedClientBlockNode;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Direction;
+import org.jetbrains.annotations.NotNull;
+
+public record SimpleClientSidedBlockNode(int hash, int classHash, @NotNull Direction side) implements ClientBlockNode, SidedClientBlockNode {
+    @Override
+    public @NotNull Identifier getRenderId() {
+        return Constants.id("simple_sided");
+    }
+
+    @Override
+    public @NotNull Direction getSide() {
+        return side;
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/render/BlockNodeRenderer.java
+++ b/src/main/java/com/kneelawk/graphlib/client/render/BlockNodeRenderer.java
@@ -1,0 +1,55 @@
+package com.kneelawk.graphlib.client.render;
+
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.graph.ClientBlockNodeHolder;
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Handles rendering a {@link ClientBlockNode}.
+ *
+ * @param <N> the specific type of client block node that this renderer handles.
+ */
+public interface BlockNodeRenderer<N extends ClientBlockNode> {
+    /**
+     * Renders the client block node.
+     * <p>
+     * The provided matrix is already translated for rendering relative to the block node's block position.
+     *
+     * @param node       the client block node to render.
+     * @param holderNode the graph-node of the current node, for ease of checking connections and block position.
+     * @param consumers  the vertex consumers to render to.
+     * @param stack      the matrix stack containing relevant transformations for rendering at the correct position.
+     * @param graph      the graph that the node belongs to.
+     * @param endpoint
+     * @param graphColor the color that this graph has been assigned.
+     */
+    void render(@NotNull N node, @NotNull Node<ClientBlockNodeHolder> holderNode,
+                @NotNull VertexConsumerProvider consumers, @NotNull MatrixStack stack, @NotNull ClientBlockGraph graph,
+                @NotNull Vec3d endpoint, int graphColor);
+
+    /**
+     * Gets the point where lines connecting to the given node should be shown connecting to.
+     * <p>
+     * This is relative to the node's block position.
+     *
+     * @param node            the node that the lines are connecting to.
+     * @param holderNode      the graph node of the current node, for ease of checking connections and block position.
+     * @param graph           the graph that the node belongs to.
+     * @param nodesAtPos      the number of nodes also sharing the same {@link net.minecraft.util.math.BlockPos} or
+     *                        {@link com.kneelawk.graphlib.util.SidedPos}.
+     * @param indexAmongNodes the index of this node in the set of nodes being rendered at this position.
+     * @param otherEndpoints  a list of all the locations previous nodes at the same position have set as their
+     *                        endpoints.
+     * @return the position, relative to the node's block position, that lines should be drawn to.
+     */
+    @NotNull Vec3d getLineEndpoint(@NotNull N node, @NotNull Node<ClientBlockNodeHolder> holderNode,
+                                   @NotNull ClientBlockGraph graph, int nodesAtPos, int indexAmongNodes,
+                                   @NotNull List<Vec3d> otherEndpoints);
+}

--- a/src/main/java/com/kneelawk/graphlib/client/render/BlockNodeRendererHolder.java
+++ b/src/main/java/com/kneelawk/graphlib/client/render/BlockNodeRendererHolder.java
@@ -1,0 +1,41 @@
+package com.kneelawk.graphlib.client.render;
+
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.graph.ClientBlockNodeHolder;
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Holds a {@link BlockNodeRenderer} and its associated class.
+ *
+ * @param nodeClass    the class of the {@link ClientBlockNode} that the renderer should render.
+ * @param nodeRenderer the block node renderer for rendering this type of block node.
+ * @param <N>          the type of {@link ClientBlockNode} that the renderer should render.
+ */
+public record BlockNodeRendererHolder<N extends ClientBlockNode>(@NotNull Class<N> nodeClass,
+                                                                 @NotNull BlockNodeRenderer<N> nodeRenderer) {
+    public void render(@NotNull ClientBlockNode node, @NotNull Node<ClientBlockNodeHolder> holderNode,
+                       @NotNull VertexConsumerProvider consumers, @NotNull MatrixStack stack,
+                       @NotNull ClientBlockGraph graph, @NotNull Vec3d endpoint, int graphColor) {
+        if (nodeClass.isInstance(node)) {
+            nodeRenderer.render(nodeClass.cast(node), holderNode, consumers, stack, graph, endpoint, graphColor);
+        }
+    }
+
+    public Vec3d getLineEndpoint(@NotNull ClientBlockNode node, @NotNull Node<ClientBlockNodeHolder> holderNode,
+                                 @NotNull ClientBlockGraph graph, int nodesAtPos, int indexAmongNodes,
+                                 @NotNull List<Vec3d> otherEndpoints) {
+        if (nodeClass.isInstance(node)) {
+            return nodeRenderer.getLineEndpoint(nodeClass.cast(node), holderNode, graph, nodesAtPos, indexAmongNodes,
+                otherEndpoints);
+        } else {
+            return Vec3d.ZERO;
+        }
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/render/DebugRenderer.java
+++ b/src/main/java/com/kneelawk/graphlib/client/render/DebugRenderer.java
@@ -1,0 +1,231 @@
+package com.kneelawk.graphlib.client.render;
+
+import com.kneelawk.graphlib.client.GraphLibClient;
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.graph.ClientBlockNodeHolder;
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import com.kneelawk.graphlib.graph.SidedClientBlockNode;
+import com.kneelawk.graphlib.graph.struct.Link;
+import com.kneelawk.graphlib.graph.struct.Node;
+import com.kneelawk.graphlib.mixin.api.RenderLayerHelper;
+import com.kneelawk.graphlib.util.SidedPos;
+import com.mojang.blaze3d.framebuffer.Framebuffer;
+import com.mojang.blaze3d.framebuffer.SimpleFramebuffer;
+import com.mojang.blaze3d.glfw.Window;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import com.mojang.blaze3d.vertex.VertexFormats;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSet;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderContext;
+import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderPhase;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.*;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public final class DebugRenderer {
+    private DebugRenderer() {
+    }
+
+    private static @Nullable Framebuffer framebuffer = null;
+    private static final Object2ObjectMap<RenderLayer, BufferBuilder> layerMap = new Object2ObjectLinkedOpenHashMap<>();
+    private static final VertexConsumerProvider.Immediate immediate =
+        VertexConsumerProvider.immediate(layerMap, new BufferBuilder(256));
+
+    private sealed interface NPos {
+    }
+
+    private record NBlockPos(BlockPos pos) implements NPos {
+    }
+
+    private record NSidedPos(SidedPos pos) implements NPos {
+    }
+
+    private static class NPosData {
+        int nodeCount = 0;
+        List<Vec3d> endpoints = new ArrayList<>();
+    }
+
+    static {
+        layerMap.put(Layers.DEBUG_LINES, new BufferBuilder(Layers.DEBUG_LINES.getExpectedBufferSize()));
+        layerMap.put(Layers.DEBUG_QUADS, new BufferBuilder(Layers.DEBUG_QUADS.getExpectedBufferSize()));
+    }
+
+    public static final class Layers extends RenderPhase {
+        private Layers(String string, Runnable runnable, Runnable runnable2) {
+            super(string, runnable, runnable2);
+        }
+
+        public static final RenderLayer DEBUG_LINES = RenderLayerHelper.of(
+            "debug_lines",
+            VertexFormats.LINES,
+            VertexFormat.DrawMode.LINES,
+            256,
+            false,
+            false,
+            RenderLayer.MultiPhaseParameters.builder()
+                .shader(RenderPhase.LINES_SHADER)
+                .lineWidth(new RenderPhase.LineWidth(OptionalDouble.empty()))
+                .transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+                .writeMaskState(RenderPhase.ALL_MASK)
+                .cull(RenderPhase.DISABLE_CULLING)
+                .build(false)
+        );
+
+        public static final RenderLayer DEBUG_QUADS = RenderLayerHelper.of(
+            "debug_quads",
+            VertexFormats.POSITION_COLOR,
+            VertexFormat.DrawMode.QUADS,
+            256,
+            false,
+            false,
+            RenderLayer.MultiPhaseParameters.builder()
+                .shader(RenderPhase.COLOR_SHADER)
+                .transparency(RenderPhase.TRANSLUCENT_TRANSPARENCY)
+                .writeMaskState(RenderPhase.ALL_MASK)
+                .cull(RenderPhase.DISABLE_CULLING)
+                .build(false)
+        );
+    }
+
+    public static void init() {
+        WorldRenderEvents.LAST.register(DebugRenderer::render);
+    }
+
+    private static void render(WorldRenderContext context) {
+        if (GraphLibClient.DEBUG_GRAPHS.isEmpty()) {
+            return;
+        }
+
+        MinecraftClient client = MinecraftClient.getInstance();
+        Window window = client.getWindow();
+        if (framebuffer == null) {
+            framebuffer = new SimpleFramebuffer(window.getFramebufferWidth(), window.getFramebufferHeight(), true,
+                MinecraftClient.IS_SYSTEM_MAC);
+            framebuffer.setClearColor(0f, 0f, 0f, 0f);
+        }
+
+        if (window.getFramebufferWidth() != framebuffer.textureWidth ||
+            window.getFramebufferHeight() != framebuffer.textureHeight) {
+            framebuffer.resize(window.getFramebufferWidth(), window.getFramebufferHeight(),
+                MinecraftClient.IS_SYSTEM_MAC);
+        }
+
+        framebuffer.clear(MinecraftClient.IS_SYSTEM_MAC);
+
+        MatrixStack mv = RenderSystem.getModelViewStack();
+        mv.push();
+        mv.loadIdentity();
+        RenderSystem.applyModelViewMatrix();
+        RenderSystem.disableDepthTest();
+
+        framebuffer.beginWrite(false);
+
+        Vec3d camPos = context.camera().getPos();
+        MatrixStack stack = context.matrixStack();
+        stack.push();
+        stack.translate(-camPos.x, -camPos.y, -camPos.z);
+
+        renderGraphs(stack);
+
+        stack.pop();
+
+        immediate.draw();
+
+        client.getFramebuffer().beginWrite(false);
+
+        RenderSystem.enableDepthTest();
+        mv.pop();
+        RenderSystem.applyModelViewMatrix();
+
+        RenderSystem.enableBlend();
+        framebuffer.draw(window.getFramebufferWidth(), window.getFramebufferHeight(), false);
+        RenderSystem.disableBlend();
+    }
+
+    private static void renderGraphs(MatrixStack stack) {
+        Map<NPos, NPosData> nodeEndpoints = new HashMap<>();
+
+        for (ClientBlockGraph graph : GraphLibClient.DEBUG_GRAPHS.values()) {
+            for (var node : graph.graph()) {
+                ClientBlockNode cbn = node.data().node();
+
+                NPos pos;
+                if (cbn instanceof SidedClientBlockNode scbn) {
+                    pos = new NSidedPos(new SidedPos(node.data().pos(), scbn.getSide()));
+                } else {
+                    pos = new NBlockPos(node.data().pos());
+                }
+
+                nodeEndpoints.computeIfAbsent(pos, nPos -> new NPosData()).nodeCount++;
+            }
+        }
+
+        for (ClientBlockGraph graph : GraphLibClient.DEBUG_GRAPHS.values()) {
+            int graphColor = RenderUtils.graphColor(graph.graphId());
+            Object2ObjectMap<Node<ClientBlockNodeHolder>, Vec3d> endpoints =
+                new Object2ObjectLinkedOpenHashMap<>(graph.graph().size());
+            ObjectSet<Link<ClientBlockNodeHolder>> links = new ObjectLinkedOpenHashSet<>();
+
+            for (var node : graph.graph()) {
+                ClientBlockNode cbn = node.data().node();
+                BlockNodeRendererHolder<?> renderer = GraphLibClient.BLOCK_NODE_RENDERER.get(cbn.getRenderId());
+                if (renderer == null) continue;
+
+                NPos pos;
+                if (cbn instanceof SidedClientBlockNode scbn) {
+                    pos = new NSidedPos(new SidedPos(node.data().pos(), scbn.getSide()));
+                } else {
+                    pos = new NBlockPos(node.data().pos());
+                }
+
+                // should never be null unless GraphLibClient.DEBUG_GRAPHS was modified by another thread
+                NPosData data = nodeEndpoints.get(pos);
+
+                Vec3d endpoint =
+                    renderer.getLineEndpoint(cbn, node, graph, data.nodeCount, data.endpoints.size(), data.endpoints);
+                endpoints.put(node, endpoint);
+                data.endpoints.add(endpoint);
+
+                BlockPos origin = node.data().pos();
+
+                stack.push();
+                stack.translate(origin.getX(), origin.getY(), origin.getZ());
+
+                renderer.render(cbn, node, immediate, stack, graph, endpoint, graphColor);
+
+                stack.pop();
+
+                links.addAll(node.connections());
+            }
+
+            VertexConsumer consumer = immediate.getBuffer(Layers.DEBUG_LINES);
+
+            for (var link : links) {
+                var nodeA = link.first();
+                var nodeB = link.second();
+
+                if (!endpoints.containsKey(nodeA) || !endpoints.containsKey(nodeB)) continue;
+
+                Vec3d endpointA = endpoints.get(nodeA);
+                Vec3d endpointB = endpoints.get(nodeB);
+                BlockPos posA = nodeA.data().pos();
+                BlockPos posB = nodeB.data().pos();
+
+                RenderUtils.drawLine(stack, consumer, (float) (posA.getX() + endpointA.x), (float) (posA.getY() + endpointA.y),
+                    (float) (posA.getZ() + endpointA.z), (float) (posB.getX() + endpointB.x),
+                    (float) (posB.getY() + endpointB.y), (float) (posB.getZ() + endpointB.z), graphColor);
+            }
+        }
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/render/RenderUtils.java
+++ b/src/main/java/com/kneelawk/graphlib/client/render/RenderUtils.java
@@ -1,0 +1,155 @@
+package com.kneelawk.graphlib.client.render;
+
+import com.google.common.math.IntMath;
+import com.mojang.blaze3d.vertex.VertexConsumer;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.math.RoundingMode;
+import java.util.Random;
+
+public class RenderUtils {
+    private static final Vec3d[][] PLANAR_VECTORS = {
+        {new Vec3d(1.0, 0.0, 0.0), new Vec3d(0.0, 0.0, 1.0)},
+        {new Vec3d(1.0, 0.0, 0.0), new Vec3d(0.0, 1.0, 0.0)},
+        {new Vec3d(0.0, 0.0, 1.0), new Vec3d(0.0, 1.0, 0.0)}
+    };
+
+    public static void drawCube(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float width, float height, float depth, int color) {
+        drawCube(stack, consumer, x, y, z, width, 0f, 0f, 0f, height, 0f, 0f, 0f, depth, color);
+    }
+
+    public static void drawCube(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float radX0, float radY0, float radZ0, float radX1, float radY1, float radZ1,
+                                float radX2, float radY2, float radZ2, int color) {
+        drawRect(stack, consumer, x - radX2, y - radY2, z - radZ2, radX0, radY0, radZ0, radX1, radY1, radZ1, color);
+        drawRect(stack, consumer, x + radX2, y + radY2, z + radZ2, radX0, radY0, radZ0, radX1, radY1, radZ1, color);
+        drawLine(stack, consumer, x - radX0 - radX1 - radX2, y - radY0 - radY1 - radY2, z - radZ0 - radZ1 - radZ2,
+            x - radX0 - radX1 + radX2, y - radY0 - radY1 + radY2, z - radZ0 - radZ1 + radZ2, color);
+        drawLine(stack, consumer, x - radX0 + radX1 - radX2, y - radY0 + radY1 - radY2, z - radZ0 + radZ1 - radZ2,
+            x - radX0 + radX1 + radX2, y - radY0 + radY1 + radY2, z - radZ0 + radZ1 + radZ2, color);
+        drawLine(stack, consumer, x + radX0 + radX1 - radX2, y + radY0 + radY1 - radY2, z + radZ0 + radZ1 - radZ2,
+            x + radX0 + radX1 + radX2, y + radY0 + radY1 + radY2, z + radZ0 + radZ1 + radZ2, color);
+        drawLine(stack, consumer, x + radX0 - radX1 - radX2, y + radY0 - radY1 - radY2, z + radZ0 - radZ1 - radZ2,
+            x + radX0 - radX1 + radX2, y + radY0 - radY1 + radY2, z + radZ0 - radZ1 + radZ2, color);
+    }
+
+    public static void drawRect(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float radX, float radY, Direction normal, int color) {
+        Vec3d[] vecs = PLANAR_VECTORS[normal.ordinal() >> 1];
+        drawRect(stack, consumer, x, y, z, (float) vecs[0].x * radX, (float) vecs[0].y * radX, (float) vecs[0].z * radX,
+            (float) vecs[1].x * radY, (float) vecs[1].y * radY, (float) vecs[1].z * radY, color);
+    }
+
+    public static void drawRect(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float radX0, float radY0, float radZ0, float radX1, float radY1, float radZ1,
+                                int color) {
+        drawLine(stack, consumer, x - radX0 - radX1, y - radY0 - radY1, z - radZ0 - radZ1, x - radX0 + radX1,
+            y - radY0 + radY1, z - radZ0 + radZ1, color);
+        drawLine(stack, consumer, x - radX0 + radX1, y - radY0 + radY1, z - radZ0 + radZ1, x + radX0 + radX1,
+            y + radY0 + radY1, z + radZ0 + radZ1, color);
+        drawLine(stack, consumer, x + radX0 + radX1, y + radY0 + radY1, z + radZ0 + radZ1, x + radX0 - radX1,
+            y + radY0 - radY1, z + radZ0 - radZ1, color);
+        drawLine(stack, consumer, x + radX0 - radX1, y + radY0 - radY1, z + radZ0 - radZ1, x - radX0 - radX1,
+            y - radY0 - radY1, z - radZ0 - radZ1, color);
+    }
+
+    public static void drawLine(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x0, float y0,
+                                float z0, float x1, float y1, float z1, int color) {
+        Matrix4f model = stack.peek().getModel();
+        Matrix3f normal = stack.peek().getNormal();
+
+        float dx = x1 - x0;
+        float dy = y1 - y0;
+        float dz = z1 - z0;
+        float fact = MathHelper.fastInverseSqrt(dx * dx + dy * dy + dz * dz);
+        dx *= fact;
+        dy *= fact;
+        dz *= fact;
+
+        consumer.vertex(model, x0, y0, z0).color(color).normal(normal, dx, dy, dz).next();
+        consumer.vertex(model, x1, y1, z1).color(color).normal(normal, dx, dy, dz).next();
+    }
+
+    public static void fillCube(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float width, float height, float depth, int color) {
+        fillCube(stack, consumer, x, y, z, width, 0f, 0f, 0f, height, 0f, 0f, 0f, depth, color);
+    }
+
+    public static void fillCube(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float radX0, float radY0, float radZ0, float radX1, float radY1, float radZ1,
+                                float radX2, float radY2, float radZ2, int color) {
+        fillRect(stack, consumer, x - radX1, y - radY1, z - radZ1, radX0, radY0, radZ0, radX2, radY2, radZ2, color);
+        fillRect(stack, consumer, x + radX1, y + radY1, z + radZ1, radX0, radY0, radZ0, -radX2, -radY2, -radZ2, color);
+        fillRect(stack, consumer, x - radX2, y - radY2, z - radZ2, -radX0, -radY0, -radZ0, radX1, radY1, radZ1, color);
+        fillRect(stack, consumer, x + radX2, y + radY2, z + radZ2, radX0, radY0, radZ0, radX1, radY1, radZ1, color);
+        fillRect(stack, consumer, x - radX0, y - radY0, z - radZ0, radX2, radY2, radZ2, radX1, radY1, radZ1, color);
+        fillRect(stack, consumer, x + radX0, y + radY0, z + radZ0, -radX2, -radY2, -radZ2, radX1, radY1, radZ1, color);
+    }
+
+    public static void fillRect(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float radX, float radY, Direction normal, int color) {
+        Vec3d[] vecs = PLANAR_VECTORS[normal.ordinal() >> 1];
+        fillRect(stack, consumer, x, y, z, (float) vecs[0].x * radX, (float) vecs[0].y * radX, (float) vecs[0].z * radX,
+            (float) vecs[1].x * radY, (float) vecs[1].y * radY, (float) vecs[1].z * radY, color);
+    }
+
+    public static void fillRect(@NotNull MatrixStack stack, @NotNull VertexConsumer consumer, float x, float y, float z,
+                                float radX0, float radY0, float radZ0, float radX1, float radY1, float radZ1,
+                                int color) {
+        Matrix4f model = stack.peek().getModel();
+
+        consumer.vertex(model, x - radX0 + radX1, y - radY0 + radY1, z - radZ0 + radZ1).color(color).next();
+        consumer.vertex(model, x - radX0 - radX1, y - radY0 - radY1, z - radZ0 - radZ1).color(color).next();
+        consumer.vertex(model, x + radX0 - radX1, y + radY0 - radY1, z + radZ0 - radZ1).color(color).next();
+        consumer.vertex(model, x + radX0 + radX1, y + radY0 + radY1, z + radZ0 + radZ1).color(color).next();
+    }
+
+    public static int graphColor(long graphId) {
+        Random rand = new Random(graphId);
+        return rand.nextInt() | 0xFF000000;
+    }
+
+    public static Vec3d distributedEndpoint(int nodesAtPos, int indexAmongNodes, Direction side, double verticalOffset,
+                                     double spacing, double verticalSpacing) {
+        Vec3d[] spacings = PLANAR_VECTORS[side.ordinal() >> 1];
+        return distributedEndpoint(
+            nodesAtPos, indexAmongNodes,
+            0.5 + side.getOffsetX() * (0.5 - verticalOffset),
+            0.5 + side.getOffsetY() * (0.5 - verticalOffset),
+            0.5 + side.getOffsetZ() * (0.5 - verticalOffset),
+            spacings[0].x * spacing, spacings[0].y * spacing, spacings[0].z * spacing,
+            spacings[1].x * spacing, spacings[1].y * spacing, spacings[1].z * spacing,
+            -side.getOffsetX() * verticalSpacing,
+            -side.getOffsetY() * verticalSpacing,
+            -side.getOffsetZ() * verticalSpacing
+        );
+    }
+
+    public static Vec3d distributedEndpoint(int nodesAtPos, int indexAmongNodes, double spacing, double verticalSpacing) {
+        return distributedEndpoint(nodesAtPos, indexAmongNodes, 0.5, 0.5, 0.5, spacing, 0.0, 0.0, 0.0, 0.0, spacing,
+            0.0, verticalSpacing, 0.0);
+    }
+
+    public static Vec3d distributedEndpoint(int nodesAtPos, int indexAmongNodes, double centerX, double centerY,
+                                     double centerZ, double spaceX0, double spaceY0, double spaceZ0, double spaceX1,
+                                     double spaceY1, double spaceZ1, double offsetX, double offsetY, double offsetZ) {
+        if (nodesAtPos < 2) {
+            return new Vec3d(centerX, centerY, centerZ);
+        }
+
+        int width = IntMath.sqrt(nodesAtPos, RoundingMode.CEILING);
+        int indexX = indexAmongNodes % width;
+        int indexY = indexAmongNodes / width;
+
+        double posX = (double) indexX - (double) (width - 1) / 2.0;
+        double posY = (double) indexY - (double) (width - 1) / 2.0;
+        double posZ = (double) indexX + (double) indexY - (double) (width - 1);
+
+        return new Vec3d(centerX + posX * spaceX0 + posY * spaceX1 + posZ * offsetX,
+            centerY + posX * spaceY0 + posY * spaceY1 + posZ * offsetY,
+            centerZ + posX * spaceZ0 + posY * spaceZ1 + posZ * offsetZ);
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/render/SimpleBlockNodeRenderer.java
+++ b/src/main/java/com/kneelawk/graphlib/client/render/SimpleBlockNodeRenderer.java
@@ -1,0 +1,35 @@
+package com.kneelawk.graphlib.client.render;
+
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.graph.ClientBlockNodeHolder;
+import com.kneelawk.graphlib.client.graph.SimpleClientBlockNode;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class SimpleBlockNodeRenderer implements BlockNodeRenderer<SimpleClientBlockNode> {
+    public static final SimpleBlockNodeRenderer INSTANCE = new SimpleBlockNodeRenderer();
+
+    private SimpleBlockNodeRenderer() {
+    }
+
+    @Override
+    public void render(@NotNull SimpleClientBlockNode node, @NotNull Node<ClientBlockNodeHolder> holderNode,
+                       @NotNull VertexConsumerProvider consumers, @NotNull MatrixStack stack,
+                       @NotNull ClientBlockGraph graph, @NotNull Vec3d endpoint, int graphColor) {
+        RenderUtils.drawCube(stack, consumers.getBuffer(DebugRenderer.Layers.DEBUG_LINES), (float) endpoint.x,
+            (float) endpoint.y, (float) endpoint.z, 3f / 64f, 3f / 64f, 3f / 64f, node.classHash() | 0xFF000000);
+    }
+
+    @Override
+    public @NotNull Vec3d getLineEndpoint(@NotNull SimpleClientBlockNode node,
+                                          @NotNull Node<ClientBlockNodeHolder> holderNode,
+                                          @NotNull ClientBlockGraph graph, int nodesAtPos, int indexAmongNodes,
+                                          @NotNull List<Vec3d> otherEndpoints) {
+        return RenderUtils.distributedEndpoint(nodesAtPos, indexAmongNodes, 1.0 / 8.0, 1.0 / 16.0);
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/client/render/SimpleSidedBlockNodeRenderer.java
+++ b/src/main/java/com/kneelawk/graphlib/client/render/SimpleSidedBlockNodeRenderer.java
@@ -1,0 +1,36 @@
+package com.kneelawk.graphlib.client.render;
+
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.client.graph.ClientBlockNodeHolder;
+import com.kneelawk.graphlib.client.graph.SimpleClientSidedBlockNode;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.math.Vec3d;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class SimpleSidedBlockNodeRenderer implements BlockNodeRenderer<SimpleClientSidedBlockNode> {
+    public static final SimpleSidedBlockNodeRenderer INSTANCE = new SimpleSidedBlockNodeRenderer();
+
+    private SimpleSidedBlockNodeRenderer() {
+    }
+
+    @Override
+    public void render(@NotNull SimpleClientSidedBlockNode node, @NotNull Node<ClientBlockNodeHolder> holderNode,
+                       @NotNull VertexConsumerProvider consumers, @NotNull MatrixStack stack,
+                       @NotNull ClientBlockGraph graph, @NotNull Vec3d endpoint, int graphColor) {
+        RenderUtils.drawRect(stack, consumers.getBuffer(DebugRenderer.Layers.DEBUG_LINES), (float) endpoint.x,
+            (float) endpoint.y, (float) endpoint.z, 3f / 64f, 3f / 64f, node.side(), node.classHash() | 0xFF000000);
+    }
+
+    @Override
+    public @NotNull Vec3d getLineEndpoint(@NotNull SimpleClientSidedBlockNode node,
+                                          @NotNull Node<ClientBlockNodeHolder> holderNode,
+                                          @NotNull ClientBlockGraph graph, int nodesAtPos, int indexAmongNodes,
+                                          @NotNull List<Vec3d> otherEndpoints) {
+        return RenderUtils.distributedEndpoint(nodesAtPos, indexAmongNodes, node.side(), 1.0 / 8.0, 1.0 / 8.0,
+            1.0 / 32.0);
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/command/GraphLibCommand.java
+++ b/src/main/java/com/kneelawk/graphlib/command/GraphLibCommand.java
@@ -2,7 +2,9 @@ package com.kneelawk.graphlib.command;
 
 import com.kneelawk.graphlib.Constants;
 import com.kneelawk.graphlib.GraphLib;
+import com.kneelawk.graphlib.net.GraphLibCommonNetworking;
 import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.command.argument.BlockPosArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.world.ServerWorld;
@@ -16,29 +18,37 @@ import static net.minecraft.server.command.CommandManager.literal;
 public class GraphLibCommand {
     public static void register(CommandDispatcher<ServerCommandSource> dispatcher) {
         dispatcher.register(literal("graphlib")
-                .requires(source -> source.hasPermissionLevel(2))
-                .then(literal("updateblocks")
-                        .then(argument("from", BlockPosArgumentType.blockPos())
-                                .then(argument("to", BlockPosArgumentType.blockPos())
-                                        .executes(context -> updateBlocks(context.getSource(),
-                                                BlockPosArgumentType.getBlockPos(context, "from"),
-                                                BlockPosArgumentType.getBlockPos(context, "to")))
-                                )
-                        )
+            .requires(source -> source.hasPermissionLevel(2))
+            .then(literal("updateblocks")
+                .then(argument("from", BlockPosArgumentType.blockPos())
+                    .then(argument("to", BlockPosArgumentType.blockPos())
+                        .executes(context -> updateBlocks(context.getSource(),
+                            BlockPosArgumentType.getBlockPos(context, "from"),
+                            BlockPosArgumentType.getBlockPos(context, "to")))
+                    )
                 )
-                .then(literal("removeemptygraphs").executes(context -> removeEmptyGraphsCommand(context.getSource())))
+            )
+            .then(literal("removeemptygraphs").executes(context -> removeEmptyGraphsCommand(context.getSource())))
+            .then(literal("debugrender")
+                .then(literal("start")
+                    .executes(context -> startDebugRender(context.getSource()))
+                )
+                .then(literal("stop")
+                    .executes(context -> stopDebugRender(context.getSource()))
+                )
+            )
         );
     }
 
     private static int updateBlocks(ServerCommandSource source, BlockPos from, BlockPos to) {
         source.sendFeedback(Constants.command("graphlib.updateblocks.starting", blockPosText(from), blockPosText(to)),
-                true);
+            true);
 
         ServerWorld world = source.getWorld();
         GraphLib.getController(world).updateNodes(BlockPos.stream(from, to));
 
         source.sendFeedback(Constants.command("graphlib.updateblocks.success", blockPosText(from), blockPosText(to)),
-                true);
+            true);
 
         return 15;
     }
@@ -51,14 +61,24 @@ public class GraphLibCommand {
         return result;
     }
 
+    private static int startDebugRender(ServerCommandSource source) throws CommandSyntaxException {
+        GraphLibCommonNetworking.startDebuggingPlayer(source.getPlayer());
+        return 15;
+    }
+
+    private static int stopDebugRender(ServerCommandSource source) throws CommandSyntaxException {
+        GraphLibCommonNetworking.stopDebuggingPlayer(source.getPlayer());
+        return 15;
+    }
+
     private static MutableText blockPosText(BlockPos pos) {
         return Texts.bracketed(Text.translatable("chat.coordinates", pos.getX(), pos.getY(), pos.getZ()))
-                .styled(
-                        style -> style.withColor(Formatting.GREEN)
-                                .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND,
-                                        "/tp @s " + pos.getX() + " " + pos.getY() + " " + pos.getZ()))
-                                .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-                                        Text.translatable("chat.coordinates.tooltip")))
-                );
+            .styled(
+                style -> style.withColor(Formatting.GREEN)
+                    .withClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND,
+                        "/tp @s " + pos.getX() + " " + pos.getY() + " " + pos.getZ()))
+                    .withHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+                        Text.translatable("chat.coordinates.tooltip")))
+            );
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/graph/BlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/BlockGraph.java
@@ -3,6 +3,7 @@ package com.kneelawk.graphlib.graph;
 import com.kneelawk.graphlib.graph.struct.Node;
 import com.kneelawk.graphlib.util.SidedPos;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkSectionPos;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.stream.Stream;
@@ -40,6 +41,13 @@ public interface BlockGraph {
      * @return a stream of all the nodes in this graph.
      */
     @NotNull Stream<Node<BlockNodeHolder>> getNodes();
+
+    /**
+     * Gets all the chunk sections that this graph currently has nodes in.
+     *
+     * @return a stream of all the chunk sections this graph is in.
+     */
+    @NotNull Stream<ChunkSectionPos> getChunks();
 
     /**
      * Gets the number of nodes in this graph.

--- a/src/main/java/com/kneelawk/graphlib/graph/ClientBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/ClientBlockNode.java
@@ -1,0 +1,20 @@
+package com.kneelawk.graphlib.graph;
+
+import net.minecraft.util.Identifier;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Implemented by any representation of a {@link BlockNode} on the client.
+ * <p>
+ * This could theoretically be implemented by the same class implementing {@link BlockNode}, as care has been taken to
+ * make sure this interface does not depend on anything strictly client-sided, but that would likely be overkill for
+ * most situations.
+ */
+public interface ClientBlockNode {
+    /**
+     * Gets the id of the renderer registered with {@link com.kneelawk.graphlib.client.GraphLibClient#BLOCK_NODE_RENDERER}.
+     *
+     * @return the id of the renderer to use to render this block node.
+     */
+    @NotNull Identifier getRenderId();
+}

--- a/src/main/java/com/kneelawk/graphlib/graph/NodeView.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/NodeView.java
@@ -3,8 +3,12 @@ package com.kneelawk.graphlib.graph;
 import com.kneelawk.graphlib.graph.struct.Node;
 import com.kneelawk.graphlib.util.SidedPos;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 /**
@@ -26,4 +30,55 @@ public interface NodeView {
      * @return a stream of all the nodes in the given sided block-position.
      */
     @NotNull Stream<Node<BlockNodeHolder>> getNodesAt(@NotNull SidedPos pos);
+
+    /**
+     * Gets the IDs of all graphs with nodes in the given block-position.
+     *
+     * @param pos the block-position to get the IDs of graphs with nodes at.
+     * @return a stream of all the IDs of graphs with nodes in the given block-position.
+     */
+    @NotNull LongStream getGraphsAt(@NotNull BlockPos pos);
+
+    /**
+     * Gets the graph with the given ID.
+     * <p>
+     * Note: this <b>may</b> involve loading the graph from the filesystem.
+     *
+     * @param id the ID of the graph to get.
+     * @return the graph with the given ID.
+     */
+    @Nullable
+    BlockGraph getGraph(long id);
+
+    /**
+     * Gets all graph ids in the given chunk section.
+     * <p>
+     * Note: Not all graph-ids returned here are guaranteed to belong to valid graphs. {@link #getGraph(long)} may
+     * return <code>null</code>.
+     *
+     * @param pos the position of the chunk section to get the graphs in.
+     * @return a stream of all graph ids in the given chunk section.
+     */
+    @NotNull LongStream getGraphsInChunkSection(@NotNull ChunkSectionPos pos);
+
+    /**
+     * Gets all graph ids in the given chunk.
+     * <p>
+     * Note: Not all graph-ids returned here are guaranteed to belong to valid graphs. {@link #getGraph(long)} may
+     * return <code>null</code>.
+     *
+     * @param pos the position of the chunk to get the graphs in.
+     * @return a stream of all graph ids in the given chunk.
+     */
+    @NotNull LongStream getGraphsInChunk(@NotNull ChunkPos pos);
+
+    /**
+     * Gets all graph ids in this graph controller.
+     * <p>
+     * Note: Not all graph-ids returned here are guaranteed to belong to valid graphs. {@link #getGraph(long)} may
+     * return <code>null</code>.
+     *
+     * @return a stream of all graph ids in this graph controller.
+     */
+    @NotNull LongStream getGraphs();
 }

--- a/src/main/java/com/kneelawk/graphlib/graph/SidedClientBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/SidedClientBlockNode.java
@@ -1,0 +1,29 @@
+package com.kneelawk.graphlib.graph;
+
+import com.kneelawk.graphlib.client.graph.ClientBlockGraph;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.util.math.Direction;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Describes a {@link ClientBlockNode} that is positioned on the side of a block.
+ */
+public interface SidedClientBlockNode extends ClientBlockNode {
+    /**
+     * The side of the block this node is positioned at.
+     * <p>
+     * The value returned here corresponds to how nodes are grouped together during rendering and influences the
+     * <code>nodeCount</code> argument passed to
+     * {@link com.kneelawk.graphlib.client.render.BlockNodeRenderer#getLineEndpoint(ClientBlockNode, Node, ClientBlockGraph, int, int, List)}.
+     * <p>
+     * A wire is determined to be on the {@link Direction#DOWN} side if it is sitting in the bottom of its block-space,
+     * on the top side of the block beneath it. A wire is determined to be on the {@link Direction#NORTH} side if it is
+     * sitting at the north side of its block-space, on the south side of the block to the north of it. This same logic
+     * applies for all directions.
+     *
+     * @return the side of the block this node is positioned at.
+     */
+    @NotNull Direction getSide();
+}

--- a/src/main/java/com/kneelawk/graphlib/graph/simple/SimpleBlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/simple/SimpleBlockGraph.java
@@ -3,6 +3,7 @@ package com.kneelawk.graphlib.graph.simple;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.kneelawk.graphlib.GLLog;
+import com.kneelawk.graphlib.GraphLibEvents;
 import com.kneelawk.graphlib.graph.BlockNode;
 import com.kneelawk.graphlib.graph.BlockNodeHolder;
 import com.kneelawk.graphlib.graph.SidedBlockNode;
@@ -190,6 +191,16 @@ public class SimpleBlockGraph implements com.kneelawk.graphlib.graph.BlockGraph 
     }
 
     /**
+     * Gets all the chunk sections that this graph currently has nodes in.
+     *
+     * @return a stream of all the chunk sections this graph is in.
+     */
+    @Override
+    public @NotNull Stream<ChunkSectionPos> getChunks() {
+        return chunks.longStream().mapToObj(ChunkSectionPos::from);
+    }
+
+    /**
      * Gets the number of nodes in this graph.
      *
      * @return the number of nodes in this graph.
@@ -366,10 +377,19 @@ public class SimpleBlockGraph implements com.kneelawk.graphlib.graph.BlockGraph 
                 }
 
                 newBlockGraphs.add(bg);
+
+                // Fire update events for the new graphs
+                GraphLibEvents.GRAPH_UPDATED.invoker().graphUpdated(controller.world, controller, bg);
             }
+
+            // Fire the update events
+            GraphLibEvents.GRAPH_UPDATED.invoker().graphUpdated(controller.world, controller, this);
 
             return newBlockGraphs;
         } else {
+            // Fire the update events
+            GraphLibEvents.GRAPH_UPDATED.invoker().graphUpdated(controller.world, controller, this);
+
             return List.of();
         }
     }

--- a/src/main/java/com/kneelawk/graphlib/graph/simple/SimpleBlockGraphController.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/simple/SimpleBlockGraphController.java
@@ -3,6 +3,7 @@ package com.kneelawk.graphlib.graph.simple;
 import com.kneelawk.graphlib.Constants;
 import com.kneelawk.graphlib.GLLog;
 import com.kneelawk.graphlib.GraphLib;
+import com.kneelawk.graphlib.GraphLibEvents;
 import com.kneelawk.graphlib.graph.BlockGraphController;
 import com.kneelawk.graphlib.graph.BlockNode;
 import com.kneelawk.graphlib.graph.BlockNodeHolder;
@@ -51,7 +52,7 @@ public class SimpleBlockGraphController implements AutoCloseable, NodeView, Bloc
      */
     private static final int MAX_AGE = 20 * 60;
 
-    private final ServerWorld world;
+    final ServerWorld world;
 
     private final UnloadingRegionBasedStorage<SimpleBlockGraphChunk> chunks;
 
@@ -374,6 +375,10 @@ public class SimpleBlockGraphController implements AutoCloseable, NodeView, Bloc
     @NotNull SimpleBlockGraph createGraph() {
         SimpleBlockGraph graph = new SimpleBlockGraph(this, getNextGraphId());
         loadedGraphs.put(graph.getId(), graph);
+
+        // Fire graph created event
+        GraphLibEvents.GRAPH_CREATED.invoker().graphCreated(world, this, graph);
+
         return graph;
     }
 
@@ -391,6 +396,9 @@ public class SimpleBlockGraphController implements AutoCloseable, NodeView, Bloc
         }
 
         destroyGraphImpl(graph);
+
+        // Fire the event
+        GraphLibEvents.GRAPH_DESTROYED.invoker().graphDestroyed(world, this, id);
     }
 
     void addGraphInPos(long id, @NotNull BlockPos pos) {
@@ -568,6 +576,8 @@ public class SimpleBlockGraphController implements AutoCloseable, NodeView, Bloc
         if (!removedConnections.isEmpty()) {
             // Split should never leave graph empty. It also should clean up after itself.
             mergedGraph.split();
+        } else {
+            GraphLibEvents.GRAPH_UPDATED.invoker().graphUpdated(world, this, mergedGraph);
         }
     }
 

--- a/src/main/java/com/kneelawk/graphlib/mixin/api/RenderLayerHelper.java
+++ b/src/main/java/com/kneelawk/graphlib/mixin/api/RenderLayerHelper.java
@@ -1,0 +1,22 @@
+package com.kneelawk.graphlib.mixin.api;
+
+import com.kneelawk.graphlib.mixin.impl.RenderLayerAccessor;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.render.RenderLayer;
+
+public final class RenderLayerHelper {
+    private RenderLayerHelper() {
+    }
+
+    public static RenderLayer of(
+        String name,
+        VertexFormat vertexFormat,
+        VertexFormat.DrawMode drawMode,
+        int expectedBufferSize,
+        boolean hasCrumbling,
+        boolean translucent,
+        RenderLayer.MultiPhaseParameters phases
+    ) {
+        return RenderLayerAccessor.callOf(name, vertexFormat, drawMode, expectedBufferSize, hasCrumbling, translucent, phases);
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/mixin/impl/RenderLayerAccessor.java
+++ b/src/main/java/com/kneelawk/graphlib/mixin/impl/RenderLayerAccessor.java
@@ -1,0 +1,22 @@
+package com.kneelawk.graphlib.mixin.impl;
+
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.render.RenderLayer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(RenderLayer.class)
+public interface RenderLayerAccessor {
+    @Invoker
+    static RenderLayer.MultiPhase callOf(
+        String name,
+        VertexFormat vertexFormat,
+        VertexFormat.DrawMode drawMode,
+        int expectedBufferSize,
+        boolean hasCrumbling,
+        boolean translucent,
+        RenderLayer.MultiPhaseParameters phases
+    ) {
+        throw new RuntimeException("RenderLayerAccessor Mixin Failure");
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/net/BlockNodePacketDecoder.java
+++ b/src/main/java/com/kneelawk/graphlib/net/BlockNodePacketDecoder.java
@@ -1,0 +1,25 @@
+package com.kneelawk.graphlib.net;
+
+import com.kneelawk.graphlib.graph.BlockNode;
+import com.kneelawk.graphlib.graph.ClientBlockNode;
+import com.kneelawk.graphlib.graph.NodeView;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.world.ServerWorld;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Used for decoding a {@link ClientBlockNode} from a {@link PacketByteBuf}.
+ */
+public interface BlockNodePacketDecoder {
+    /**
+     * Decodes a {@link ClientBlockNode} from a {@link PacketByteBuf}.
+     *
+     * @param buf a buffer for reading the data written by
+     *            {@link com.kneelawk.graphlib.net.BlockNodePacketEncoder#toPacket(BlockNode, Node, ServerWorld, NodeView, PacketByteBuf)}.
+     *            Note: this buffer will contain other data besides this node's data.
+     * @return a {@link ClientBlockNode} containing the data decoded from the {@link PacketByteBuf}.
+     */
+    @Nullable ClientBlockNode fromPacket(@NotNull PacketByteBuf buf);
+}

--- a/src/main/java/com/kneelawk/graphlib/net/BlockNodePacketEncoder.java
+++ b/src/main/java/com/kneelawk/graphlib/net/BlockNodePacketEncoder.java
@@ -1,0 +1,29 @@
+package com.kneelawk.graphlib.net;
+
+import com.kneelawk.graphlib.graph.BlockNode;
+import com.kneelawk.graphlib.graph.BlockNodeHolder;
+import com.kneelawk.graphlib.graph.NodeView;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.world.ServerWorld;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Used for encoding a {@link BlockNode} to a {@link PacketByteBuf} for sending to the client for debug rendering.
+ *
+ * @param <N> the exact type of {@link BlockNode} this is designed to encode.
+ */
+public interface BlockNodePacketEncoder<N extends BlockNode> {
+    /**
+     * Encodes a {@link BlockNode} to a {@link PacketByteBuf}.
+     *
+     * Note the given buffer will have {@link BlockNode}s encoded before and after this one.
+     * @param node the block node to encode.
+     * @param holderNode
+     * @param world
+     * @param view
+     * @param buf
+     */
+    void toPacket(@NotNull N node, @NotNull Node<BlockNodeHolder> holderNode, @NotNull ServerWorld world,
+                  @NotNull NodeView view, @NotNull PacketByteBuf buf);
+}

--- a/src/main/java/com/kneelawk/graphlib/net/BlockNodePacketEncoderHolder.java
+++ b/src/main/java/com/kneelawk/graphlib/net/BlockNodePacketEncoderHolder.java
@@ -1,0 +1,26 @@
+package com.kneelawk.graphlib.net;
+
+import com.kneelawk.graphlib.graph.BlockNode;
+import com.kneelawk.graphlib.graph.BlockNodeHolder;
+import com.kneelawk.graphlib.graph.NodeView;
+import com.kneelawk.graphlib.graph.struct.Node;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.world.ServerWorld;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Holds a {@link BlockNodePacketEncoder} along with the class of its associated {@link BlockNode}.
+ *
+ * @param nodeClass   the class of the block node the encoder is associated with.
+ * @param nodeEncoder the encoder for encoding the associated type of block node.
+ * @param <N>         the type of the block node the encoder is associated with.
+ */
+public record BlockNodePacketEncoderHolder<N extends BlockNode>(@NotNull Class<N> nodeClass,
+                                                                @NotNull BlockNodePacketEncoder<N> nodeEncoder) {
+    public void toPacket(@NotNull BlockNode node, @NotNull Node<BlockNodeHolder> holderNode, @NotNull ServerWorld world,
+                         @NotNull NodeView view, @NotNull PacketByteBuf buf) {
+        if (nodeClass.isInstance(node)) {
+            nodeEncoder.toPacket(nodeClass.cast(node), holderNode, world, view, buf);
+        }
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/net/GraphLibCommonNetworking.java
+++ b/src/main/java/com/kneelawk/graphlib/net/GraphLibCommonNetworking.java
@@ -1,0 +1,226 @@
+package com.kneelawk.graphlib.net;
+
+import com.kneelawk.graphlib.Constants;
+import com.kneelawk.graphlib.GLLog;
+import com.kneelawk.graphlib.GraphLib;
+import com.kneelawk.graphlib.GraphLibEvents;
+import com.kneelawk.graphlib.graph.*;
+import com.kneelawk.graphlib.graph.struct.Link;
+import com.kneelawk.graphlib.graph.struct.Node;
+import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.PlayerManager;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.server.world.ThreadedAnvilChunkStorage;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class GraphLibCommonNetworking {
+    private GraphLibCommonNetworking() {
+    }
+
+    public static final Identifier ID_MAP_BULK_ID = Constants.id("id_map_bulk");
+    public static final Identifier ID_MAP_PUT_ID = Constants.id("id_map_put");
+    public static final Identifier GRAPH_UPDATE_ID = Constants.id("graph_update");
+    public static final Identifier GRAPH_UPDATE_BULK_ID = Constants.id("graph_update_bulk");
+    public static final Identifier GRAPH_DESTROY_ID = Constants.id("graph_destroy");
+    public static final Identifier DEBUGGING_STOP_ID = Constants.id("debugging_stop");
+
+    public static final BlockNodePacketEncoder<BlockNode> DEFAULT_ENCODER = (node, holderNode, world, view, buf) -> {
+        // This keeps otherwise identical-looking client-side nodes separate.
+        buf.writeInt(node.hashCode());
+        buf.writeInt(node.getClass().getName().hashCode());
+
+        if (node instanceof SidedBlockNode sided) {
+            buf.writeByte(1);
+            buf.writeByte(sided.getSide().getId());
+        } else {
+            buf.writeByte(0);
+        }
+    };
+
+    private static final Set<UUID> debuggingPlayers = new LinkedHashSet<>();
+    private static final Object2IntMap<Identifier> idMap = new Object2IntLinkedOpenHashMap<>();
+
+    public static void startDebuggingPlayer(ServerPlayerEntity player) {
+        sendIdMap(player);
+        debuggingPlayers.add(player.getUuid());
+
+        ServerWorld world = player.getWorld();
+        MinecraftServer server = world.getServer();
+        BlockGraphController controller = GraphLib.getController(world);
+        int viewDistance = server.getPlayerManager().getViewDistance();
+
+        ChunkSectionPos playerPos = player.getWatchedSection();
+        int minX = playerPos.getSectionX() - viewDistance - 1;
+        int minZ = playerPos.getSectionZ() - viewDistance - 1;
+        int maxX = playerPos.getSectionX() + viewDistance + 1;
+        int maxZ = playerPos.getSectionZ() + viewDistance + 1;
+
+        LongSet graphs = new LongLinkedOpenHashSet();
+        for (int z = minZ; z <= maxZ; z++) {
+            for (int x = minX; x <= maxX; x++) {
+                if (ThreadedAnvilChunkStorage.isWithinDistance(x, z, playerPos.getSectionX(), playerPos.getSectionZ(),
+                    viewDistance)) {
+                    ChunkPos pos = new ChunkPos(x, z);
+
+                    controller.getGraphsInChunk(pos).forEach(graphs::add);
+                }
+            }
+        }
+
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeVarInt(graphs.size());
+
+        for (long graphId : graphs) {
+            BlockGraph graph = controller.getGraph(graphId);
+
+            if (graph != null) {
+                encodeBlockGraph(world, controller, graph, buf);
+            }
+        }
+
+        ServerPlayNetworking.send(player, GRAPH_UPDATE_BULK_ID, buf);
+    }
+
+    public static void stopDebuggingPlayer(ServerPlayerEntity player) {
+        debuggingPlayers.remove(player.getUuid());
+
+        ServerPlayNetworking.send(player, DEBUGGING_STOP_ID, PacketByteBufs.empty());
+    }
+
+    public static void init() {
+        ServerLifecycleEvents.SERVER_STARTING.register(server -> debuggingPlayers.clear());
+        ServerLifecycleEvents.SERVER_STOPPED.register(server -> debuggingPlayers.clear());
+        ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> stopDebuggingPlayer(handler.player));
+
+        GraphLibEvents.GRAPH_CREATED.register(GraphLibCommonNetworking::sendBlockGraph);
+        GraphLibEvents.GRAPH_UPDATED.register(GraphLibCommonNetworking::sendBlockGraph);
+        GraphLibEvents.GRAPH_DESTROYED.register((world, controller, id) -> {
+            PacketByteBuf buf = PacketByteBufs.create();
+            buf.writeLong(id);
+
+            sendToDebuggingPlayers(world, GRAPH_DESTROY_ID, buf);
+        });
+    }
+
+    private static void sendIdMap(ServerPlayerEntity player) {
+        PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeVarInt(idMap.size());
+        for (var entry : idMap.object2IntEntrySet()) {
+            buf.writeIdentifier(entry.getKey());
+            buf.writeVarInt(entry.getIntValue());
+        }
+        ServerPlayNetworking.send(player, ID_MAP_BULK_ID, buf);
+    }
+
+    private static int getIdentifierInt(ServerWorld world, Identifier id) {
+        if (idMap.containsKey(id)) {
+            return idMap.get(id);
+        } else {
+            int index = idMap.size();
+            idMap.put(id, index);
+
+            PacketByteBuf buf = PacketByteBufs.create();
+            buf.writeIdentifier(id);
+            buf.writeVarInt(index);
+            sendToDebuggingPlayers(world, ID_MAP_PUT_ID, buf);
+
+            return index;
+        }
+    }
+
+    private static void sendBlockGraph(ServerWorld world, BlockGraphController controller, BlockGraph graph) {
+        if (debuggingPlayers.isEmpty()) {
+            return;
+        }
+
+        PacketByteBuf buf = PacketByteBufs.create();
+        encodeBlockGraph(world, controller, graph, buf);
+
+        Set<ServerPlayerEntity> sendTo = new LinkedHashSet<>();
+        graph.getChunks().forEachOrdered(section -> {
+            for (ServerPlayerEntity player : PlayerLookup.tracking(world, section.toChunkPos())) {
+                if (debuggingPlayers.contains(player.getUuid())) {
+                    sendTo.add(player);
+                }
+            }
+        });
+
+        for (ServerPlayerEntity player : sendTo) {
+            ServerPlayNetworking.send(player, GRAPH_UPDATE_ID, buf);
+        }
+    }
+
+    private static void encodeBlockGraph(ServerWorld world, BlockGraphController controller, BlockGraph graph,
+                                         PacketByteBuf buf) {
+        buf.writeLong(graph.getId());
+
+        AtomicInteger index = new AtomicInteger();
+        Map<Node<BlockNodeHolder>, Integer> indexMap = new HashMap<>();
+        Set<Link<BlockNodeHolder>> distinct = new LinkedHashSet<>();
+
+        buf.writeVarInt(graph.size());
+        graph.getNodes().forEachOrdered(node -> {
+            buf.writeVarInt(getIdentifierInt(world, node.data().getNode().getTypeId()));
+            buf.writeBlockPos(node.data().getPos());
+            encodeBlockNode(world, controller, node, buf);
+            indexMap.put(node, index.getAndIncrement());
+            distinct.addAll(node.connections());
+        });
+
+        buf.writeVarInt(distinct.size());
+        for (Link<BlockNodeHolder> link : distinct) {
+            if (!indexMap.containsKey(link.first())) {
+                GLLog.warn(
+                    "Attempted to save link with non-existent node. Graph Id: {}, offending node: {}, missing node: {}",
+                    graph.getId(), link.second(), link.first());
+                continue;
+            }
+            if (!indexMap.containsKey(link.second())) {
+                GLLog.warn(
+                    "Attempted to save link with non-existent node. Graph Id: {}, offending node: {}, missing node: {}",
+                    graph.getId(), link.first(), link.second());
+                continue;
+            }
+            buf.writeVarInt(indexMap.get(link.first()));
+            buf.writeVarInt(indexMap.get(link.second()));
+        }
+    }
+
+    private static void encodeBlockNode(ServerWorld world, NodeView view, Node<BlockNodeHolder> node,
+                                        PacketByteBuf buf) {
+        BlockNodePacketEncoderHolder<?> holder =
+            GraphLib.BLOCK_NODE_PACKET_ENCODER.get(node.data().getNode().getTypeId());
+
+        if (holder != null) {
+            holder.toPacket(node.data().getNode(), node, world, view, buf);
+        } else {
+            DEFAULT_ENCODER.toPacket(node.data().getNode(), node, world, view, buf);
+        }
+    }
+
+    private static void sendToDebuggingPlayers(ServerWorld world, Identifier packetId, PacketByteBuf buf) {
+        PlayerManager manager = world.getServer().getPlayerManager();
+        for (UUID playerId : debuggingPlayers) {
+            ServerPlayerEntity player = manager.getPlayer(playerId);
+            if (player != null) {
+                ServerPlayNetworking.send(player, packetId, buf);
+            }
+        }
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,11 +20,17 @@
       {
         "value": "com.kneelawk.graphlib.GraphLibFabricMod"
       }
+    ],
+    "client": [
+      {
+        "value": "com.kneelawk.graphlib.client.GraphLibFabricModClient"
+      }
     ]
   },
   "mixins": [
     "graphlib.mixins.json"
   ],
+  "accessWidener": "graphlib.accesswidener",
   "depends": {
     "fabricloader": ">=0.13.0",
     "fabric": "*",

--- a/src/main/resources/graphlib.accesswidener
+++ b/src/main/resources/graphlib.accesswidener
@@ -1,0 +1,5 @@
+accessWidener   v1      named
+
+# RenderLayer access wideners
+accessible      class   net/minecraft/client/render/RenderLayer$MultiPhase
+accessible      class   net/minecraft/client/render/RenderLayer$MultiPhaseParameters

--- a/src/main/resources/graphlib.mixins.json
+++ b/src/main/resources/graphlib.mixins.json
@@ -5,6 +5,9 @@
   "injectors": {
     "defaultRequire": 1
   },
+  "client": [
+    "RenderLayerAccessor"
+  ],
   "mixins": [
     "StorageIoWorkerAccessor",
     "ThreadedAnvilChunkStorageMixin"


### PR DESCRIPTION
# This PR
This PR adds debug rendering for graph nodes so that it is easier to tell how nodes are actually connected and debug their usage.

## Screenshots
![2022-12-16_14 56 38](https://user-images.githubusercontent.com/2180089/208538473-8ec33250-22a4-4572-bab9-48748817fd94.png)

# Associated Issues
This PR closes #5.