### PR TITLE
Add Center-Wire Connection Support

### DIFF
--- a/src/main/java/com/kneelawk/graphlib/graph/BlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/graph/BlockNode.java
@@ -11,6 +11,8 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
 import com.kneelawk.graphlib.graph.struct.Node;
+import com.kneelawk.graphlib.wire.CenterWireBlockNode;
+import com.kneelawk.graphlib.wire.CenterWireConnectionFilter;
 import com.kneelawk.graphlib.wire.FullWireBlockNode;
 import com.kneelawk.graphlib.wire.FullWireConnectionFilter;
 import com.kneelawk.graphlib.wire.SidedWireBlockNode;
@@ -61,6 +63,7 @@ public interface BlockNode {
      * @return all nodes this node can connect to.
      * @see com.kneelawk.graphlib.wire.WireConnectionDiscoverers#wireFindConnections(SidedWireBlockNode, ServerWorld, NodeView, BlockPos, Node, SidedWireConnectionFilter)
      * @see com.kneelawk.graphlib.wire.WireConnectionDiscoverers#fullBlockFindConnections(FullWireBlockNode, ServerWorld, NodeView, BlockPos, Node, FullWireConnectionFilter)
+     * @see com.kneelawk.graphlib.wire.WireConnectionDiscoverers#centerWireFindConnections(CenterWireBlockNode, ServerWorld, NodeView, BlockPos, Node, CenterWireConnectionFilter)
      */
     @NotNull Collection<Node<BlockNodeHolder>> findConnections(@NotNull ServerWorld world, @NotNull NodeView nodeView,
                                                                @NotNull BlockPos pos,
@@ -79,6 +82,7 @@ public interface BlockNode {
      * @return whether this node can connect to the other node.
      * @see com.kneelawk.graphlib.wire.WireConnectionDiscoverers#wireCanConnect(SidedWireBlockNode, ServerWorld, BlockPos, Node, Node, SidedWireConnectionFilter)
      * @see com.kneelawk.graphlib.wire.WireConnectionDiscoverers#fullBlockCanConnect(FullWireBlockNode, ServerWorld, BlockPos, Node, Node, FullWireConnectionFilter)
+     * @see com.kneelawk.graphlib.wire.WireConnectionDiscoverers#centerWireCanConnect(CenterWireBlockNode, ServerWorld, BlockPos, Node, Node, CenterWireConnectionFilter)
      */
     boolean canConnect(@NotNull ServerWorld world, @NotNull NodeView nodeView, @NotNull BlockPos pos,
                        @NotNull Node<BlockNodeHolder> self, @NotNull Node<BlockNodeHolder> other);

--- a/src/main/java/com/kneelawk/graphlib/wire/CenterWireBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/wire/CenterWireBlockNode.java
@@ -1,0 +1,18 @@
+package com.kneelawk.graphlib.wire;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+import com.kneelawk.graphlib.graph.BlockNode;
+import com.kneelawk.graphlib.graph.BlockNodeHolder;
+import com.kneelawk.graphlib.graph.struct.Node;
+
+public interface CenterWireBlockNode extends BlockNode {
+    default boolean canConnect(@NotNull ServerWorld world, @NotNull BlockPos pos, @NotNull Direction onSide,
+                               @NotNull Node<BlockNodeHolder> self, @NotNull Node<BlockNodeHolder> other) {
+        return true;
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/wire/CenterWireBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/wire/CenterWireBlockNode.java
@@ -10,7 +10,21 @@ import com.kneelawk.graphlib.graph.BlockNode;
 import com.kneelawk.graphlib.graph.BlockNodeHolder;
 import com.kneelawk.graphlib.graph.struct.Node;
 
+/**
+ * A block node that sits, hovering in the center of the block but without taking up the entire block space.
+ */
 public interface CenterWireBlockNode extends BlockNode {
+    /**
+     * Checks whether this block node can connect to the given other block node.
+     *
+     * @param world  the block world that both nodes are in.
+     * @param pos    the block position of this node.
+     * @param onSide the side of this block that the other node is trying to connect to.
+     * @param self   the block node holder associated with this block node.
+     * @param other  the block node holder holding the other node.
+     * @return <code>true</code> if this node and the other node should be allowed to connect, <code>false</code>
+     * otherwise.
+     */
     default boolean canConnect(@NotNull ServerWorld world, @NotNull BlockPos pos, @NotNull Direction onSide,
                                @NotNull Node<BlockNodeHolder> self, @NotNull Node<BlockNodeHolder> other) {
         return true;

--- a/src/main/java/com/kneelawk/graphlib/wire/CenterWireConnectionFilter.java
+++ b/src/main/java/com/kneelawk/graphlib/wire/CenterWireConnectionFilter.java
@@ -1,0 +1,30 @@
+package com.kneelawk.graphlib.wire;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+
+import com.kneelawk.graphlib.graph.BlockNodeHolder;
+import com.kneelawk.graphlib.graph.struct.Node;
+
+/**
+ * Allows an external object to filter the connections connecting to a center wire block node.
+ */
+public interface CenterWireConnectionFilter {
+    /**
+     * Checks whether this filter allows the two block nodes to connect.
+     *
+     * @param self      the node that this check is with respect to.
+     * @param world     the block world that both nodes are in.
+     * @param pos       the block position of this node.
+     * @param onSide    the side of this block that the other node is trying to connect to.
+     * @param selfNode  the block node holder associated with this block node.
+     * @param otherNode the block node holder holding the other node.
+     * @return <code>true</code> if the two nodes should be allowed to connect, <code>false</code> otherwise.
+     */
+    boolean canConnect(@NotNull CenterWireBlockNode self, @NotNull ServerWorld world, @NotNull BlockPos pos,
+                       @NotNull Direction onSide, @NotNull Node<BlockNodeHolder> selfNode,
+                       @NotNull Node<BlockNodeHolder> otherNode);
+}

--- a/src/main/java/com/kneelawk/graphlib/wire/WireConnectionDiscoverers.java
+++ b/src/main/java/com/kneelawk/graphlib/wire/WireConnectionDiscoverers.java
@@ -11,6 +11,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
+import com.kneelawk.graphlib.graph.BlockNode;
 import com.kneelawk.graphlib.graph.BlockNodeHolder;
 import com.kneelawk.graphlib.graph.NodeView;
 import com.kneelawk.graphlib.graph.struct.Node;
@@ -92,11 +93,12 @@ public final class WireConnectionDiscoverers {
                                          @Nullable SidedWireConnectionFilter filter) {
         Direction side = self.getSide();
         BlockPos otherPos = otherNode.data().getPos();
+        BlockNode other = otherNode.data().getNode();
 
         BlockPos posDiff = otherPos.subtract(pos);
         Direction posDiffDir = Direction.fromVector(posDiff);
 
-        if (otherNode.data().getNode() instanceof SidedWireBlockNode otherSidedNode) {
+        if (other instanceof SidedWireBlockNode otherSidedNode) {
             Direction otherSide = otherSidedNode.getSide();
 
             // check internal connections first
@@ -129,15 +131,21 @@ public final class WireConnectionDiscoverers {
             }
 
             return false;
-        } else if (otherNode.data().getNode() instanceof FullWireBlockNode) {
+        } else if (other instanceof FullWireBlockNode) {
             // implementing external connections here might be useful, but I don't see a use for them right now
             WireConnectionType type = side.equals(posDiffDir) ? WireConnectionType.UNDER : WireConnectionType.EXTERNAL;
 
             return posDiffDir != null && !posDiffDir.equals(side.getOpposite()) &&
                 (filter == null || filter.canConnect(self, world, pos, posDiffDir, type, selfNode, otherNode)) &&
                 self.canConnect(world, pos, posDiffDir, type, selfNode, otherNode);
+        } else if (other instanceof CenterWireBlockNode) {
+            // center-wire connections are only valid if we're both in the same block
+            return posDiffDir == null && (filter == null ||
+                filter.canConnect(self, world, pos, side.getOpposite(), WireConnectionType.ABOVE, selfNode,
+                    otherNode)) &&
+                self.canConnect(world, pos, side.getOpposite(), WireConnectionType.ABOVE, selfNode, otherNode);
         } else {
-            // we only know how to handle connections to SidedWireBlockNodes and FullWireBlockNodes for now
+            // we only know how to handle connections to SidedWireBlockNodes, CenterWireBlockNodes, and FullWireBlockNodes for now
             return false;
         }
     }
@@ -186,6 +194,7 @@ public final class WireConnectionDiscoverers {
                                               @NotNull Node<BlockNodeHolder> otherNode,
                                               @Nullable FullWireConnectionFilter filter) {
         BlockPos otherPos = otherNode.data().getPos();
+        BlockNode other = otherNode.data().getNode();
 
         BlockPos posDiff = otherPos.subtract(pos);
         Direction posDiffDir = Direction.fromVector(posDiff);
@@ -194,16 +203,82 @@ public final class WireConnectionDiscoverers {
             return false;
         }
 
-        if (otherNode.data().getNode() instanceof FullWireBlockNode) {
+        if (other instanceof FullWireBlockNode || other instanceof CenterWireBlockNode) {
             return (filter == null || filter.canConnect(self, world, pos, posDiffDir, null, selfNode, otherNode)) &&
                 self.canConnect(world, pos, posDiffDir, null, selfNode, otherNode);
-        } else if (otherNode.data().getNode() instanceof SidedWireBlockNode otherSidedNode) {
+        } else if (other instanceof SidedWireBlockNode otherSidedNode) {
             Direction otherSide = otherSidedNode.getSide();
             return !otherSide.equals(posDiffDir) && (filter == null ||
                 filter.canConnect(self, world, pos, posDiffDir, otherSide, selfNode, otherNode)) &&
                 self.canConnect(world, pos, posDiffDir, otherSide, selfNode, otherNode);
         } else {
-            // we only know how to handle connections to SidedWireBlockNodes and FullWireBlockNodes for now
+            // we only know how to handle connections to SidedWireBlockNodes, CenterWireBlockNodes, and FullWireBlockNodes for now
+            return false;
+        }
+    }
+
+    /**
+     * Finds nodes that can connect to this center-wire node.
+     *
+     * @param self     this node.
+     * @param world    the block world to find connections in.
+     * @param nodeView the node world to find connections in.
+     * @param pos      the position of this node.
+     * @param selfNode this node's holder.
+     * @param filter   a general connection filter, used to filter connections.
+     * @return a collection of nodes this node can connect to.
+     */
+    public static @NotNull Collection<Node<BlockNodeHolder>> centerWireFindConnections(
+        @NotNull CenterWireBlockNode self, @NotNull ServerWorld world, @NotNull NodeView nodeView,
+        @NotNull BlockPos pos, @NotNull Node<BlockNodeHolder> selfNode, @Nullable CenterWireConnectionFilter filter) {
+        List<Node<BlockNodeHolder>> collector = new ArrayList<>();
+
+        // add internal connections
+        nodeView.getNodesAt(pos).filter(other -> centerWireCanConnect(self, world, pos, selfNode, other, filter))
+            .forEach(collector::add);
+
+        // add external connections
+        for (Direction external : Direction.values()) {
+            nodeView.getNodesAt(pos.offset(external))
+                .filter(other -> centerWireCanConnect(self, world, pos, selfNode, other, filter))
+                .forEach(collector::add);
+        }
+
+        return collector;
+    }
+
+    /**
+     * Checks if this center-wire node can connect to the given node.
+     *
+     * @param self      this node.
+     * @param world     the block world to check the connection in.
+     * @param pos       this node's position.
+     * @param selfNode  this node's holder.
+     * @param otherNode the node that this node could potentially connect to.
+     * @param filter    a general connection filter, used to filter connections.
+     * @return <code>true</code> if this node can connect to the given node.
+     */
+    public static boolean centerWireCanConnect(@NotNull CenterWireBlockNode self, @NotNull ServerWorld world,
+                                               @NotNull BlockPos pos, @NotNull Node<BlockNodeHolder> selfNode,
+                                               @NotNull Node<BlockNodeHolder> otherNode,
+                                               @Nullable CenterWireConnectionFilter filter) {
+        BlockPos otherPos = otherNode.data().getPos();
+        BlockNode other = otherNode.data().getNode();
+
+        BlockPos posDiff = otherPos.subtract(pos);
+        Direction posDiffDir = Direction.fromVector(posDiff);
+
+        if (other instanceof CenterWireBlockNode || other instanceof FullWireBlockNode) {
+            return posDiffDir != null &&
+                (filter == null || filter.canConnect(self, world, pos, posDiffDir, selfNode, otherNode)) &&
+                self.canConnect(world, pos, posDiffDir, selfNode, otherNode);
+        } else if (other instanceof SidedWireBlockNode otherSided) {
+            Direction otherSide = otherSided.getSide();
+            return posDiffDir == null &&
+                (filter == null || filter.canConnect(self, world, pos, otherSide, selfNode, otherNode)) &&
+                self.canConnect(world, pos, otherSide, selfNode, otherNode);
+        } else {
+            // we only know how to handle connections to SidedWireBlockNodes, CenterWireBlockNodes, and FullWireBlockNodes for now
             return false;
         }
     }

--- a/src/main/java/com/kneelawk/graphlib/wire/WireConnectionType.java
+++ b/src/main/java/com/kneelawk/graphlib/wire/WireConnectionType.java
@@ -25,7 +25,8 @@ public enum WireConnectionType {
     UNDER,
 
     /**
-     * Not currently used. Could be used for jacketed cable connections eventually.
+     * Connection to something above this wire but in the same block, like a center-wire (e.g. standing cables, lamps,
+     * powerline-connectors, etc.).
      */
     ABOVE
 }


### PR DESCRIPTION
# This PR
This PR adds a new type of wire block-nodes, `CenterWireBlockNode`s. This PR also adds methods to `WireConnectionDiscoverers` for connecting these new nodes. These nodes exist in the center of blocks and can only connect to sided-wires from the top of the wire. These nodes can connect to each other and full-block nodes in different block spaces.
