### PR TITLE
Use NodeHolders instead of Nodes in API

### DIFF
--- a/src/main/java/com/kneelawk/graphlib/api/client/BlockNodePacketDecoder.java
+++ b/src/main/java/com/kneelawk/graphlib/api/client/BlockNodePacketDecoder.java
@@ -5,12 +5,11 @@ import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 
 import com.kneelawk.graphlib.api.graph.GraphView;
+import com.kneelawk.graphlib.api.graph.NodeHolder;
 import com.kneelawk.graphlib.api.node.BlockNode;
 import com.kneelawk.graphlib.api.node.client.ClientBlockNode;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * Used for decoding a {@link ClientBlockNode} from a {@link PacketByteBuf}.
@@ -20,7 +19,7 @@ public interface BlockNodePacketDecoder {
      * Decodes a {@link ClientBlockNode} from a {@link PacketByteBuf}.
      *
      * @param buf a buffer for reading the data written by
-     *            {@link BlockNode#toPacket(ServerWorld, GraphView, BlockPos, Node, PacketByteBuf)}.
+     *            {@link BlockNode#toPacket(NodeHolder, ServerWorld, GraphView, PacketByteBuf)}.
      *            Note: this buffer will contain other data besides this node's data.
      * @return a {@link ClientBlockNode} containing the data decoded from the {@link PacketByteBuf}.
      */

--- a/src/main/java/com/kneelawk/graphlib/api/client/GraphLibClient.java
+++ b/src/main/java/com/kneelawk/graphlib/api/client/GraphLibClient.java
@@ -8,15 +8,14 @@ import net.fabricmc.api.Environment;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.BlockPos;
 
 import com.kneelawk.graphlib.api.client.render.BlockNodeRenderer;
-import com.kneelawk.graphlib.impl.client.render.BlockNodeRendererHolder;
 import com.kneelawk.graphlib.api.graph.GraphView;
+import com.kneelawk.graphlib.api.graph.NodeHolder;
 import com.kneelawk.graphlib.api.node.BlockNode;
 import com.kneelawk.graphlib.api.node.client.ClientBlockNode;
-import com.kneelawk.graphlib.api.util.graph.Node;
 import com.kneelawk.graphlib.impl.client.GraphLibClientImpl;
+import com.kneelawk.graphlib.impl.client.render.BlockNodeRendererHolder;
 
 /**
  * Graph Lib Client-Side Public API. This class contains static methods and fields for registering
@@ -31,7 +30,7 @@ public final class GraphLibClient {
      * Registers a {@link BlockNodePacketDecoder} in the given universe for the given block node type id.
      * <p>
      * Only register a decoder if you implement
-     * {@link BlockNode#toPacket(ServerWorld, GraphView, BlockPos, Node, PacketByteBuf)}
+     * {@link BlockNode#toPacket(NodeHolder, ServerWorld, GraphView, PacketByteBuf)}
      * to provide custom node data to the client.
      *
      * @param universeId the universe this decoder is to be registered under.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
@@ -7,6 +7,8 @@ import org.jetbrains.annotations.NotNull;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkSectionPos;
 
+import com.kneelawk.graphlib.api.node.BlockNode;
+import com.kneelawk.graphlib.api.node.SidedBlockNode;
 import com.kneelawk.graphlib.api.util.SidedPos;
 import com.kneelawk.graphlib.api.util.graph.Node;
 
@@ -27,7 +29,7 @@ public interface BlockGraph {
      * @param pos the block-position to get the nodes in.
      * @return a stream of all the nodes in this graph in the given block-position.
      */
-    @NotNull Stream<Node<NodeHolder>> getNodesAt(@NotNull BlockPos pos);
+    @NotNull Stream<NodeHolder<BlockNode>> getNodesAt(@NotNull BlockPos pos);
 
     /**
      * Gets all the nodes in this graph in the given sided block-position.
@@ -35,14 +37,14 @@ public interface BlockGraph {
      * @param pos the sided block-position to get the nodes in.
      * @return a stream of all the nodes in this graph in the given sided block-position.
      */
-    @NotNull Stream<Node<NodeHolder>> getNodesAt(@NotNull SidedPos pos);
+    @NotNull Stream<NodeHolder<SidedBlockNode>> getNodesAt(@NotNull SidedPos pos);
 
     /**
      * Gets all the nodes in this graph.
      *
      * @return a stream of all the nodes in this graph.
      */
-    @NotNull Stream<Node<NodeHolder>> getNodes();
+    @NotNull Stream<NodeHolder<BlockNode>> getNodes();
 
     /**
      * Gets all nodes in this graph with the given type.
@@ -50,7 +52,7 @@ public interface BlockGraph {
      * @param type the type that all returned nodes must be.
      * @return a stream of all the nodes in this graph with the given type.
      */
-    @NotNull Stream<Node<NodeHolder>> getNodesOfType(@NotNull Class<?> type);
+    @NotNull <T extends BlockNode> Stream<NodeHolder<T>> getNodesOfType(@NotNull Class<T> type);
 
     /**
      * Gets all the chunk sections that this graph currently has nodes in.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
@@ -10,7 +10,6 @@ import net.minecraft.util.math.ChunkSectionPos;
 import com.kneelawk.graphlib.api.node.BlockNode;
 import com.kneelawk.graphlib.api.node.SidedBlockNode;
 import com.kneelawk.graphlib.api.util.SidedPos;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * Holds and manages a set of block nodes.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
@@ -14,7 +14,6 @@ import net.minecraft.util.math.ChunkSectionPos;
 import com.kneelawk.graphlib.api.node.BlockNode;
 import com.kneelawk.graphlib.api.node.SidedBlockNode;
 import com.kneelawk.graphlib.api.util.SidedPos;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * Interface that allows access to the nodes at given positions.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
@@ -11,6 +11,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.ChunkSectionPos;
 
+import com.kneelawk.graphlib.api.node.BlockNode;
+import com.kneelawk.graphlib.api.node.SidedBlockNode;
 import com.kneelawk.graphlib.api.util.SidedPos;
 import com.kneelawk.graphlib.api.util.graph.Node;
 
@@ -31,7 +33,7 @@ public interface GraphView {
      * @param pos the block-position to get the nodes in.
      * @return a stream of all the nodes in the given block-position.
      */
-    @NotNull Stream<Node<NodeHolder>> getNodesAt(@NotNull BlockPos pos);
+    @NotNull Stream<NodeHolder<BlockNode>> getNodesAt(@NotNull BlockPos pos);
 
     /**
      * Gets the nodes in the given sided block-position.
@@ -39,7 +41,7 @@ public interface GraphView {
      * @param pos the sided block-position to get the nodes in.
      * @return a stream of all the nodes in the given sided block-position.
      */
-    @NotNull Stream<Node<NodeHolder>> getNodesAt(@NotNull SidedPos pos);
+    @NotNull Stream<NodeHolder<SidedBlockNode>> getNodesAt(@NotNull SidedPos pos);
 
     /**
      * Gets the IDs of all graphs with nodes in the given block-position.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
@@ -1,48 +1,17 @@
 package com.kneelawk.graphlib.api.graph;
 
-import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.util.math.ChunkSectionPos;
 
 import com.kneelawk.graphlib.api.util.SidedPos;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * Holds and manages all block graphs for a given world.
  */
 public interface GraphWorld extends GraphView {
-
-    /**
-     * Gets all nodes in the given block-position.
-     *
-     * @param pos the block-position to get nodes in.
-     * @return a stream of the nodes in the given block-position.
-     */
-    @Override
-    @NotNull Stream<Node<NodeHolder>> getNodesAt(@NotNull BlockPos pos);
-
-    /**
-     * Gets all nodes in the given sided block-position.
-     *
-     * @param pos the sided block-position to get the nodes in.
-     * @return a stream of the nodes in the given sided block-position.
-     */
-    @Override
-    @NotNull Stream<Node<NodeHolder>> getNodesAt(@NotNull SidedPos pos);
-
-    /**
-     * Gets the IDs of all graphs with nodes in the given block-position.
-     *
-     * @param pos the block-position to get the IDs of graphs with nodes at.
-     * @return a stream of all the IDs of graphs with nodes in the given block-position.
-     */
-    @NotNull LongStream getGraphsAt(@NotNull BlockPos pos);
 
     /**
      * Notifies the controller that a block-position has been changed and may need to have its nodes and connections
@@ -81,47 +50,4 @@ public interface GraphWorld extends GraphView {
      * @param pos the sided block-position of the nodes to update connections for.
      */
     void updateConnections(@NotNull SidedPos pos);
-
-    /**
-     * Gets the graph with the given ID.
-     * <p>
-     * Note: this <b>may</b> involve loading the graph from the filesystem.
-     *
-     * @param id the ID of the graph to get.
-     * @return the graph with the given ID.
-     */
-    @Nullable
-    BlockGraph getGraph(long id);
-
-    /**
-     * Gets all graph ids in the given chunk section.
-     * <p>
-     * Note: Not all graph-ids returned here are guaranteed to belong to valid graphs. {@link #getGraph(long)} may
-     * return <code>null</code>.
-     *
-     * @param pos the position of the chunk section to get the graphs in.
-     * @return a stream of all graph ids in the given chunk section.
-     */
-    @NotNull LongStream getGraphsInChunkSection(@NotNull ChunkSectionPos pos);
-
-    /**
-     * Gets all graph ids in the given chunk.
-     * <p>
-     * Note: Not all graph-ids returned here are guaranteed to belong to valid graphs. {@link #getGraph(long)} may
-     * return <code>null</code>.
-     *
-     * @param pos the position of the chunk to get the graphs in.
-     * @return a stream of all graph ids in the given chunk.
-     */
-    @NotNull LongStream getGraphsInChunk(@NotNull ChunkPos pos);
-
-    /**
-     * Gets all graph ids in this graph controller.
-     * <p>
-     * Note: Not all graph-ids returned here are guaranteed to belong to valid graphs. {@link #getGraph(long)} may
-     * return <code>null</code>.
-     *
-     * @return a stream of all graph ids in this graph controller.
-     */
-    @NotNull LongStream getGraphs();
 }

--- a/src/main/java/com/kneelawk/graphlib/api/graph/NodeConnection.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/NodeConnection.java
@@ -1,0 +1,47 @@
+package com.kneelawk.graphlib.api.graph;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.kneelawk.graphlib.api.node.BlockNode;
+
+/**
+ * Describes a connection between two nodes. May contain its own data, depending on implementation.
+ */
+public interface NodeConnection {
+    /**
+     * @return the first node in this connection.
+     */
+    @NotNull NodeHolder<BlockNode> getFirst();
+
+    /**
+     * @return the second node in this connection.
+     */
+    @NotNull NodeHolder<BlockNode> getSecond();
+
+    /**
+     * Checks whether either node is the given node.
+     *
+     * @param node the node to check against.
+     * @return <code>true</code> if either node matches the given node.
+     */
+    default boolean contains(@NotNull NodeHolder<BlockNode> node) {
+        return Objects.equals(getFirst(), node) || Objects.equals(getSecond(), node);
+    }
+
+    /**
+     * Gets the node opposite the given node.
+     *
+     * @param node the node to get the other end of the connection from.
+     * @return the node at the other end of the connection from the given node.
+     */
+    default @NotNull NodeHolder<BlockNode> other(@NotNull NodeHolder<BlockNode> node) {
+        NodeHolder<BlockNode> first = getFirst();
+        if (Objects.equals(first, node)) {
+            return getSecond();
+        } else {
+            return first;
+        }
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/api/graph/NodeHolder.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/NodeHolder.java
@@ -1,5 +1,7 @@
 package com.kneelawk.graphlib.api.graph;
 
+import java.util.Collection;
+
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.util.math.BlockPos;
@@ -11,8 +13,10 @@ import com.kneelawk.graphlib.api.node.BlockNode;
  * <p>
  * All block nodes are associated with a block-position and are wrapped in a block-node-holder that stores the position
  * information along with information about what graph the block node is a part of.
+ *
+ * @param <T> the type of node this holder is holding.
  */
-public interface NodeHolder {
+public interface NodeHolder<T extends BlockNode> {
     /**
      * Gets this block node holder's block position.
      *
@@ -25,7 +29,7 @@ public interface NodeHolder {
      *
      * @return the BlockNode this holder is holding.
      */
-    @NotNull BlockNode getNode();
+    @NotNull T getNode();
 
     /**
      * Gets the graph id of the graph that this node is part of.
@@ -33,4 +37,40 @@ public interface NodeHolder {
      * @return the graph id of this node.
      */
     long getGraphId();
+
+    /**
+     * Gets all the connections this node has with other nodes.
+     *
+     * @return a collection of all the {@link NodeConnection}s this node has with other nodes.
+     */
+    @NotNull Collection<NodeConnection> getConnections();
+
+    /**
+     * Gets an immutable view of this node holder's position and node.
+     *
+     * @return a positioned node containing this holder's position and node.
+     */
+    @NotNull PositionedNode<T> toPositionedNode();
+
+    /**
+     * Checks whether the contained node can be cast to the new type.
+     * <p>
+     * Tool to get around Java's broken type-variance system.
+     *
+     * @param newType the type the internal node is to be cast to.
+     * @return <code>true</code> if the internal node is of the correct type to be cast.
+     */
+    boolean canCast(Class<?> newType);
+
+    /**
+     * Casts the internal node to the given type.
+     * <p>
+     * Tool to get around Java's broken type-variance system.
+     *
+     * @param newType the type the internal node is to be cast to.
+     * @param <R>     the type the internal node is to be cast to.
+     * @return a node-holder containing the new type.
+     * @throws ClassCastException if the cast failed.
+     */
+    <R extends BlockNode> NodeHolder<R> cast(Class<R> newType) throws ClassCastException;
 }

--- a/src/main/java/com/kneelawk/graphlib/api/graph/PositionedNode.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/PositionedNode.java
@@ -1,0 +1,32 @@
+package com.kneelawk.graphlib.api.graph;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.util.math.BlockPos;
+
+import com.kneelawk.graphlib.api.node.BlockNode;
+
+/**
+ * Immutable version of {@link NodeHolder}, holding only a node and its position.
+ * <p>
+ * This can be useful if a set of nodes needs to be sent to another thread for processing.
+ *
+ * @param pos  the block position of the node.
+ * @param node the node itself.
+ * @param <T>  the specific type of the node.
+ */
+public record PositionedNode<T extends BlockNode>(@NotNull BlockPos pos, @NotNull T node, long graphId) {
+    /**
+     * Creates a PositionedNode.
+     *
+     * @param pos  the block position of the node.
+     * @param node the node itself.
+     */
+    @ApiStatus.Internal
+    public PositionedNode(@NotNull BlockPos pos, @NotNull T node, long graphId) {
+        this.pos = pos.toImmutable();
+        this.node = node;
+        this.graphId = graphId;
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/api/node/SidedBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/api/node/SidedBlockNode.java
@@ -4,13 +4,11 @@ import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.GraphView;
 import com.kneelawk.graphlib.api.graph.NodeHolder;
 import com.kneelawk.graphlib.api.util.SidedPos;
-import com.kneelawk.graphlib.api.util.graph.Node;
 import com.kneelawk.graphlib.api.wire.WireConnectionDiscoverers;
 import com.kneelawk.graphlib.impl.graph.simple.SimpleGraphWorld;
 
@@ -45,15 +43,14 @@ public interface SidedBlockNode extends BlockNode {
      * This method does <b>not</b> need to be implemented in order for client-side graph debug rendering to work.
      * This method should only be overridden to provide custom data to the client.
      *
+     * @param self      this block node's holder, providing information about this node's connections and graph id.
      * @param world     the block world that this node is associated with.
      * @param graphView the world of nodes.
-     * @param pos       the block position of this node.
-     * @param self      this block node's holder, providing information about this node's connections and graph id.
      * @param buf       the buffer to encode this node to.
      */
     @Override
-    default void toPacket(@NotNull ServerWorld world, @NotNull GraphView graphView, @NotNull BlockPos pos,
-                          @NotNull Node<NodeHolder> self, @NotNull PacketByteBuf buf) {
+    default void toPacket(@NotNull NodeHolder<BlockNode> self, @NotNull ServerWorld world,
+                          @NotNull GraphView graphView, @NotNull PacketByteBuf buf) {
         // This keeps otherwise identical-looking client-side nodes separate.
         buf.writeInt(hashCode());
 

--- a/src/main/java/com/kneelawk/graphlib/api/wire/CenterWireBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/CenterWireBlockNode.java
@@ -3,12 +3,10 @@ package com.kneelawk.graphlib.api.wire;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
 import com.kneelawk.graphlib.api.node.BlockNode;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * A block node that sits, hovering in the center of the block but without taking up the entire block space.
@@ -17,16 +15,15 @@ public interface CenterWireBlockNode extends BlockNode {
     /**
      * Checks whether this block node can connect to the given other block node.
      *
-     * @param world  the block world that both nodes are in.
-     * @param pos    the block position of this node.
-     * @param onSide the side of this block that the other node is trying to connect to.
      * @param self   the block node holder associated with this block node.
+     * @param world  the block world that both nodes are in.
+     * @param onSide the side of this block that the other node is trying to connect to.
      * @param other  the block node holder holding the other node.
      * @return <code>true</code> if this node and the other node should be allowed to connect, <code>false</code>
      * otherwise.
      */
-    default boolean canConnect(@NotNull ServerWorld world, @NotNull BlockPos pos, @NotNull Direction onSide,
-                               @NotNull Node<NodeHolder> self, @NotNull Node<NodeHolder> other) {
+    default boolean canConnect(@NotNull NodeHolder<BlockNode> self, @NotNull ServerWorld world,
+                               @NotNull Direction onSide, @NotNull NodeHolder<BlockNode> other) {
         return true;
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/api/wire/CenterWireConnectionFilter.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/CenterWireConnectionFilter.java
@@ -3,11 +3,10 @@ package com.kneelawk.graphlib.api.wire;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
-import com.kneelawk.graphlib.api.util.graph.Node;
+import com.kneelawk.graphlib.api.node.BlockNode;
 
 /**
  * Allows an external object to filter the connections connecting to a center wire block node.
@@ -17,14 +16,13 @@ public interface CenterWireConnectionFilter {
      * Checks whether this filter allows the two block nodes to connect.
      *
      * @param self      the node that this check is with respect to.
-     * @param world     the block world that both nodes are in.
-     * @param pos       the block position of this node.
-     * @param onSide    the side of this block that the other node is trying to connect to.
      * @param selfNode  the block node holder associated with this block node.
+     * @param world     the block world that both nodes are in.
+     * @param onSide    the side of this block that the other node is trying to connect to.
      * @param otherNode the block node holder holding the other node.
      * @return <code>true</code> if the two nodes should be allowed to connect, <code>false</code> otherwise.
      */
-    boolean canConnect(@NotNull CenterWireBlockNode self, @NotNull ServerWorld world, @NotNull BlockPos pos,
-                       @NotNull Direction onSide, @NotNull Node<NodeHolder> selfNode,
-                       @NotNull Node<NodeHolder> otherNode);
+    boolean canConnect(@NotNull CenterWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode,
+                       @NotNull ServerWorld world, @NotNull Direction onSide,
+                       @NotNull NodeHolder<BlockNode> otherNode);
 }

--- a/src/main/java/com/kneelawk/graphlib/api/wire/FullWireBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/FullWireBlockNode.java
@@ -4,12 +4,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
 import com.kneelawk.graphlib.api.node.BlockNode;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * A block node wire that occupies a full block instead of sitting on the side of a block.
@@ -20,19 +18,18 @@ public interface FullWireBlockNode extends BlockNode {
     /**
      * Checks whether this block node can connect to the given other block node.
      *
+     * @param self     the block node holder associated with this block node.
      * @param world    the block world that both nodes are in.
-     * @param pos      the position of this block node.
      * @param onSide   the side of this block node that the other node is trying to connect to.
      * @param wireSide the side of the block that the connecting wire is at, or <code>null</code> if the wire is a full
      *                 block or otherwise non-sided.
-     * @param self     the block node holder associated with this block node.
      * @param other    the block node that could possibly connect to this node.
      * @return <code>true</code> if this node and the other node should be allowed to connect, <code>false</code>
      * otherwise.
      */
-    default boolean canConnect(@NotNull ServerWorld world, @NotNull BlockPos pos, @NotNull Direction onSide,
-                               @Nullable Direction wireSide, @NotNull Node<NodeHolder> self,
-                               @NotNull Node<NodeHolder> other) {
+    default boolean canConnect(@NotNull NodeHolder<BlockNode> self, @NotNull ServerWorld world,
+                               @NotNull Direction onSide, @Nullable Direction wireSide,
+                               @NotNull NodeHolder<BlockNode> other) {
         return true;
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/api/wire/FullWireConnectionFilter.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/FullWireConnectionFilter.java
@@ -4,11 +4,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
-import com.kneelawk.graphlib.api.util.graph.Node;
+import com.kneelawk.graphlib.api.node.BlockNode;
 
 /**
  * Allows an external object to filter the connections connecting to a full block wire block node.
@@ -18,18 +17,17 @@ public interface FullWireConnectionFilter {
      * Checks whether this filter allows the two block nodes to connect.
      *
      * @param self      the node that the check is with respect to.
+     * @param selfNode  the node holder of the node that this check is with respect to.
      * @param world     the block world that both nodes are in.
-     * @param pos       the position of the <code>self</code> node.
      * @param onSide    the side of the <code>self</code> node that the other node would connect to.
      * @param wireSide  the side of its block the other node is at, or <code>null</code> if it is a full block or
      *                  otherwise un-sided.
-     * @param selfNode  the node holder of the node that this check is with respect to.
      * @param otherNode the other node that the <code>self</code> node would connect to.
      * @return <code>true</code> if the two node should be allowed to connect, <code>false</code> otherwise.
      */
-    boolean canConnect(@NotNull FullWireBlockNode self, @NotNull ServerWorld world, @NotNull BlockPos pos,
-                       @NotNull Direction onSide, @Nullable Direction wireSide, @NotNull Node<NodeHolder> selfNode,
-                       @NotNull Node<NodeHolder> otherNode);
+    boolean canConnect(@NotNull FullWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode,
+                       @NotNull ServerWorld world, @NotNull Direction onSide, @Nullable Direction wireSide,
+                       @NotNull NodeHolder<BlockNode> otherNode);
 
     /**
      * Creates a new connection filter that must satisfy both this filter and the other filter.
@@ -38,8 +36,8 @@ public interface FullWireConnectionFilter {
      * @return a new connection filter that must satisfy both this filter and the other filter.
      */
     default FullWireConnectionFilter and(@NotNull FullWireConnectionFilter otherFilter) {
-        return (self, world, pos, onSide, wireSide, selfNode, otherNode) ->
-            canConnect(self, world, pos, onSide, wireSide, selfNode, otherNode) &&
-                otherFilter.canConnect(self, world, pos, onSide, wireSide, selfNode, otherNode);
+        return (self, selfNode, world, onSide, wireSide, otherNode) ->
+            canConnect(self, selfNode, world, onSide, wireSide, otherNode) &&
+                otherFilter.canConnect(self, selfNode, world, onSide, wireSide, otherNode);
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/api/wire/SidedWireBlockNode.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/SidedWireBlockNode.java
@@ -3,12 +3,11 @@ package com.kneelawk.graphlib.api.wire;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
+import com.kneelawk.graphlib.api.node.BlockNode;
 import com.kneelawk.graphlib.api.node.SidedBlockNode;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * A block node wire that occupies the side of a block.
@@ -19,17 +18,16 @@ public interface SidedWireBlockNode extends SidedBlockNode {
     /**
      * Checks whether this sided block node can connect to the given other block node.
      *
+     * @param self           the block node holder associated with this node.
      * @param world          the block world that both nodes are in.
-     * @param pos            the block-position that this node is at.
      * @param inDirection    the direction that the other node is connecting from.
      * @param connectionType the type of connection that would be formed.
-     * @param self           the block node holder associated with this node.
      * @param other          the other block node.
      * @return <code>true</code> if a connection should be allowed to form, <code>false</code> otherwise.
      */
-    default boolean canConnect(@NotNull ServerWorld world, @NotNull BlockPos pos, @NotNull Direction inDirection,
-                               @NotNull WireConnectionType connectionType, @NotNull Node<NodeHolder> self,
-                               @NotNull Node<NodeHolder> other) {
+    default boolean canConnect(@NotNull NodeHolder<BlockNode> self, @NotNull ServerWorld world,
+                               @NotNull Direction inDirection, @NotNull WireConnectionType connectionType,
+                               @NotNull NodeHolder<BlockNode> other) {
         return true;
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/api/wire/SidedWireConnectionFilter.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/SidedWireConnectionFilter.java
@@ -3,11 +3,10 @@ package com.kneelawk.graphlib.api.wire;
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
-import com.kneelawk.graphlib.api.util.graph.Node;
+import com.kneelawk.graphlib.api.node.BlockNode;
 
 /**
  * Allows an external object to filter the connections connecting to a sided wire block node.
@@ -17,16 +16,16 @@ public interface SidedWireConnectionFilter {
      * Checks whether this filter allows two block nodes to connect.
      *
      * @param self           the node that the check is with respect to.
+     * @param selfNode       the block node holder associated with this node.
      * @param world          the block world that both nodes are in.
-     * @param pos            the block-position of the <code>self</code> node.
      * @param inDirection    the direction that the other node is connecting from.
      * @param connectionType the type of connection that would be formed.
      * @param otherNode      the other block node.
      * @return <code>true</code> if the two block nodes should be allowed to connect, <code>false</code> otherwise.
      */
-    boolean canConnect(@NotNull SidedWireBlockNode self, @NotNull ServerWorld world, @NotNull BlockPos pos,
-                       @NotNull Direction inDirection, @NotNull WireConnectionType connectionType,
-                       @NotNull Node<NodeHolder> selfNode, @NotNull Node<NodeHolder> otherNode);
+    boolean canConnect(@NotNull SidedWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode,
+                       @NotNull ServerWorld world, @NotNull Direction inDirection,
+                       @NotNull WireConnectionType connectionType, @NotNull NodeHolder<BlockNode> otherNode);
 
     /**
      * Creates a new connection filter that must satisfy both this filter and the other filter.
@@ -35,8 +34,8 @@ public interface SidedWireConnectionFilter {
      * @return a new connection filter that must satisfy both this filter and the other filter.
      */
     default SidedWireConnectionFilter and(@NotNull SidedWireConnectionFilter otherFilter) {
-        return (self, world, pos, inDirection, connectionType, selfNode, otherNode) ->
-            canConnect(self, world, pos, inDirection, connectionType, selfNode, otherNode) &&
-                otherFilter.canConnect(self, world, pos, inDirection, connectionType, selfNode, otherNode);
+        return (self, selfNode, world, inDirection, connectionType, otherNode) ->
+            canConnect(self, selfNode, world, inDirection, connectionType, otherNode) &&
+                otherFilter.canConnect(self, selfNode, world, inDirection, connectionType, otherNode);
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/api/wire/WireConnectionDiscoverers.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/WireConnectionDiscoverers.java
@@ -15,7 +15,6 @@ import com.kneelawk.graphlib.api.graph.GraphView;
 import com.kneelawk.graphlib.api.graph.NodeHolder;
 import com.kneelawk.graphlib.api.node.BlockNode;
 import com.kneelawk.graphlib.api.util.DirectionUtils;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * Contains wire connection finder and checker implementations for use in {@link BlockNode}
@@ -29,45 +28,44 @@ public final class WireConnectionDiscoverers {
      * Finds nodes that can connect to this wire node.
      * <p>
      * This is intended for use in
-     * {@link BlockNode#findConnections(ServerWorld, GraphView, BlockPos, Node)} implementations.
+     * {@link BlockNode#findConnections(NodeHolder, ServerWorld, GraphView)} implementations.
      *
      * @param self      this node.
+     * @param selfNode  this node's holder.
      * @param world     the block world to find connections in.
      * @param graphView the node world to find connections in.
-     * @param pos       this node's position.
-     * @param selfNode  this node's holder.
      * @param filter    a general connection filter, used to filter connections.
      * @return a collection of nodes this node can connect to.
-     * @see BlockNode#findConnections(ServerWorld, GraphView, BlockPos, Node)
+     * @see BlockNode#findConnections(NodeHolder, ServerWorld, GraphView)
      */
-    public static @NotNull Collection<Node<NodeHolder>> wireFindConnections(@NotNull SidedWireBlockNode self,
-                                                                            @NotNull ServerWorld world,
-                                                                            @NotNull GraphView graphView,
-                                                                            @NotNull BlockPos pos,
-                                                                            @NotNull Node<NodeHolder> selfNode,
-                                                                            @Nullable SidedWireConnectionFilter filter) {
+    public static @NotNull Collection<NodeHolder<BlockNode>> wireFindConnections(@NotNull SidedWireBlockNode self,
+                                                                                 @NotNull NodeHolder<BlockNode> selfNode,
+                                                                                 @NotNull ServerWorld world,
+                                                                                 @NotNull GraphView graphView,
+                                                                                 @Nullable SidedWireConnectionFilter filter) {
+        BlockPos pos = selfNode.getPos();
         Direction side = self.getSide();
-        List<Node<NodeHolder>> collector = new ArrayList<>();
+        List<NodeHolder<BlockNode>> collector = new ArrayList<>();
 
         // add all the internal connections
-        graphView.getNodesAt(pos).filter(other -> wireCanConnect(self, world, pos, selfNode, other, filter))
+        graphView.getNodesAt(pos).filter(other -> wireCanConnect(self, selfNode, world, other, filter))
             .forEach(collector::add);
 
         // add all external connections
         for (Direction external : DirectionUtils.perpendiculars(side)) {
             graphView.getNodesAt(pos.offset(external))
-                .filter(other -> wireCanConnect(self, world, pos, selfNode, other, filter)).forEach(collector::add);
+                .filter(other -> wireCanConnect(self, selfNode, world, other, filter)).forEach(collector::add);
         }
 
         // add all corner connections
         BlockPos under = pos.offset(side);
         for (Direction corner : DirectionUtils.perpendiculars(side)) {
             graphView.getNodesAt(under.offset(corner))
-                .filter(other -> wireCanConnect(self, world, pos, selfNode, other, filter)).forEach(collector::add);
+                .filter(other -> wireCanConnect(self, selfNode, world, other, filter)).forEach(collector::add);
         }
 
         // add full-block under connection
-        graphView.getNodesAt(under).filter(other -> wireCanConnect(self, world, pos, selfNode, other, filter))
+        graphView.getNodesAt(under).filter(other -> wireCanConnect(self, selfNode, world, other, filter))
             .forEach(collector::add);
 
         return collector;
@@ -77,23 +75,22 @@ public final class WireConnectionDiscoverers {
      * Checks if this wire node can connect to the given node.
      * <p>
      * This is intended for use in
-     * {@link BlockNode#canConnect(ServerWorld, GraphView, BlockPos, Node, Node)} implementations.
+     * {@link BlockNode#canConnect(NodeHolder, ServerWorld, GraphView, NodeHolder)} implementations.
      *
      * @param self      this node.
-     * @param world     the block world to check the connection in.
-     * @param pos       this node's position.
      * @param selfNode  this node's holder.
+     * @param world     the block world to check the connection in.
      * @param otherNode the node that this node could potentially connect to.
      * @param filter    a general connection filter, used to filter connections.
      * @return <code>true</code> if this node can connect to the given node.
      */
-    public static boolean wireCanConnect(@NotNull SidedWireBlockNode self, @NotNull ServerWorld world,
-                                         @NotNull BlockPos pos, @NotNull Node<NodeHolder> selfNode,
-                                         @NotNull Node<NodeHolder> otherNode,
+    public static boolean wireCanConnect(@NotNull SidedWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode,
+                                         @NotNull ServerWorld world, @NotNull NodeHolder<BlockNode> otherNode,
                                          @Nullable SidedWireConnectionFilter filter) {
+        BlockPos pos = selfNode.getPos();
         Direction side = self.getSide();
-        BlockPos otherPos = otherNode.data().getPos();
-        BlockNode other = otherNode.data().getNode();
+        BlockPos otherPos = otherNode.getPos();
+        BlockNode other = otherNode.getNode();
 
         BlockPos posDiff = otherPos.subtract(pos);
         Direction posDiffDir = Direction.fromVector(posDiff);
@@ -104,17 +101,15 @@ public final class WireConnectionDiscoverers {
             // check internal connections first
             if (otherPos.equals(pos)) {
                 return !otherSide.getAxis().equals(side.getAxis()) && (filter == null ||
-                    filter.canConnect(self, world, pos, otherSide, WireConnectionType.INTERNAL, selfNode,
-                        otherNode)) &&
-                    self.canConnect(world, pos, otherSide, WireConnectionType.INTERNAL, selfNode, otherNode);
+                    filter.canConnect(self, selfNode, world, otherSide, WireConnectionType.INTERNAL, otherNode)) &&
+                    self.canConnect(selfNode, world, otherSide, WireConnectionType.INTERNAL, otherNode);
             }
 
             // next check the external connections
             if (posDiffDir != null) {
                 return !posDiffDir.getAxis().equals(side.getAxis()) && otherSide.equals(side) && (filter == null ||
-                    filter.canConnect(self, world, pos, posDiffDir, WireConnectionType.EXTERNAL, selfNode,
-                        otherNode)) &&
-                    self.canConnect(world, pos, posDiffDir, WireConnectionType.EXTERNAL, selfNode, otherNode);
+                    filter.canConnect(self, selfNode, world, posDiffDir, WireConnectionType.EXTERNAL, otherNode)) &&
+                    self.canConnect(selfNode, world, posDiffDir, WireConnectionType.EXTERNAL, otherNode);
             }
 
             // finally check the corner connections
@@ -125,9 +120,8 @@ public final class WireConnectionDiscoverers {
             if (underPosDiffDir != null) {
                 return !underPosDiffDir.getAxis().equals(side.getAxis()) &&
                     otherSide.equals(underPosDiffDir.getOpposite()) && (filter == null ||
-                    filter.canConnect(self, world, pos, underPosDiffDir, WireConnectionType.CORNER, selfNode,
-                        otherNode)) &&
-                    self.canConnect(world, pos, underPosDiffDir, WireConnectionType.CORNER, selfNode, otherNode);
+                    filter.canConnect(self, selfNode, world, underPosDiffDir, WireConnectionType.CORNER, otherNode)) &&
+                    self.canConnect(selfNode, world, underPosDiffDir, WireConnectionType.CORNER, otherNode);
             }
 
             return false;
@@ -136,14 +130,13 @@ public final class WireConnectionDiscoverers {
             WireConnectionType type = side.equals(posDiffDir) ? WireConnectionType.UNDER : WireConnectionType.EXTERNAL;
 
             return posDiffDir != null && !posDiffDir.equals(side.getOpposite()) &&
-                (filter == null || filter.canConnect(self, world, pos, posDiffDir, type, selfNode, otherNode)) &&
-                self.canConnect(world, pos, posDiffDir, type, selfNode, otherNode);
+                (filter == null || filter.canConnect(self, selfNode, world, posDiffDir, type, otherNode)) &&
+                self.canConnect(selfNode, world, posDiffDir, type, otherNode);
         } else if (other instanceof CenterWireBlockNode) {
             // center-wire connections are only valid if we're both in the same block
             return posDiffDir == null && (filter == null ||
-                filter.canConnect(self, world, pos, side.getOpposite(), WireConnectionType.ABOVE, selfNode,
-                    otherNode)) &&
-                self.canConnect(world, pos, side.getOpposite(), WireConnectionType.ABOVE, selfNode, otherNode);
+                filter.canConnect(self, selfNode, world, side.getOpposite(), WireConnectionType.ABOVE, otherNode)) &&
+                self.canConnect(selfNode, world, side.getOpposite(), WireConnectionType.ABOVE, otherNode);
         } else {
             // we only know how to handle connections to SidedWireBlockNodes, CenterWireBlockNodes, and FullWireBlockNodes for now
             return false;
@@ -154,25 +147,23 @@ public final class WireConnectionDiscoverers {
      * Finds nodes that can connect to this full-block node.
      *
      * @param self      this node.
+     * @param selfNode  this node's holder.
      * @param world     the block world to find connections in.
      * @param graphView the node world to find connections in.
-     * @param pos       the position of this node.
-     * @param selfNode  this node's holder.
      * @param filter    a general connection filter, used to filter connections.
      * @return a collection of nodes this node can connect to.
      */
-    public static @NotNull Collection<Node<NodeHolder>> fullBlockFindConnections(@NotNull FullWireBlockNode self,
-                                                                                 @NotNull ServerWorld world,
-                                                                                 @NotNull GraphView graphView,
-                                                                                 @NotNull BlockPos pos,
-                                                                                 @NotNull Node<NodeHolder> selfNode,
-                                                                                 @Nullable FullWireConnectionFilter filter) {
-        List<Node<NodeHolder>> collector = new ArrayList<>();
+    public static @NotNull Collection<NodeHolder<BlockNode>> fullBlockFindConnections(@NotNull FullWireBlockNode self,
+                                                                                      @NotNull NodeHolder<BlockNode> selfNode,
+                                                                                      @NotNull ServerWorld world,
+                                                                                      @NotNull GraphView graphView,
+                                                                                      @Nullable FullWireConnectionFilter filter) {
+        BlockPos pos = selfNode.getPos();
+        List<NodeHolder<BlockNode>> collector = new ArrayList<>();
 
         for (Direction side : Direction.values()) {
             graphView.getNodesAt(pos.offset(side))
-                .filter(other -> fullBlockCanConnect(self, world, pos, selfNode, other, filter))
-                .forEach(collector::add);
+                .filter(other -> fullBlockCanConnect(self, selfNode, world, other, filter)).forEach(collector::add);
         }
 
         return collector;
@@ -182,19 +173,18 @@ public final class WireConnectionDiscoverers {
      * Checks if this full-block node can connect to the given node.
      *
      * @param self      this node.
-     * @param world     the block world to check the connection in.
-     * @param pos       this node's position.
      * @param selfNode  this node's holder.
+     * @param world     the block world to check the connection in.
      * @param otherNode the node that this node could potentially connect to.
      * @param filter    a general connection filter, used to filter connections.
      * @return <code>true</code> if this node can connect to the given node.
      */
-    public static boolean fullBlockCanConnect(@NotNull FullWireBlockNode self, @NotNull ServerWorld world,
-                                              @NotNull BlockPos pos, @NotNull Node<NodeHolder> selfNode,
-                                              @NotNull Node<NodeHolder> otherNode,
+    public static boolean fullBlockCanConnect(@NotNull FullWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode,
+                                              @NotNull ServerWorld world, @NotNull NodeHolder<BlockNode> otherNode,
                                               @Nullable FullWireConnectionFilter filter) {
-        BlockPos otherPos = otherNode.data().getPos();
-        BlockNode other = otherNode.data().getNode();
+        BlockPos pos = selfNode.getPos();
+        BlockPos otherPos = otherNode.getPos();
+        BlockNode other = otherNode.getNode();
 
         BlockPos posDiff = otherPos.subtract(pos);
         Direction posDiffDir = Direction.fromVector(posDiff);
@@ -204,13 +194,13 @@ public final class WireConnectionDiscoverers {
         }
 
         if (other instanceof FullWireBlockNode || other instanceof CenterWireBlockNode) {
-            return (filter == null || filter.canConnect(self, world, pos, posDiffDir, null, selfNode, otherNode)) &&
-                self.canConnect(world, pos, posDiffDir, null, selfNode, otherNode);
+            return (filter == null || filter.canConnect(self, selfNode, world, posDiffDir, null, otherNode)) &&
+                self.canConnect(selfNode, world, posDiffDir, null, otherNode);
         } else if (other instanceof SidedWireBlockNode otherSidedNode) {
             Direction otherSide = otherSidedNode.getSide();
-            return !otherSide.equals(posDiffDir) && (filter == null ||
-                filter.canConnect(self, world, pos, posDiffDir, otherSide, selfNode, otherNode)) &&
-                self.canConnect(world, pos, posDiffDir, otherSide, selfNode, otherNode);
+            return !otherSide.equals(posDiffDir) &&
+                (filter == null || filter.canConnect(self, selfNode, world, posDiffDir, otherSide, otherNode)) &&
+                self.canConnect(selfNode, world, posDiffDir, otherSide, otherNode);
         } else {
             // we only know how to handle connections to SidedWireBlockNodes, CenterWireBlockNodes, and FullWireBlockNodes for now
             return false;
@@ -221,26 +211,28 @@ public final class WireConnectionDiscoverers {
      * Finds nodes that can connect to this center-wire node.
      *
      * @param self      this node.
+     * @param selfNode  this node's holder.
      * @param world     the block world to find connections in.
      * @param graphView the node world to find connections in.
-     * @param pos       the position of this node.
-     * @param selfNode  this node's holder.
      * @param filter    a general connection filter, used to filter connections.
      * @return a collection of nodes this node can connect to.
      */
-    public static @NotNull Collection<Node<NodeHolder>> centerWireFindConnections(
-        @NotNull CenterWireBlockNode self, @NotNull ServerWorld world, @NotNull GraphView graphView,
-        @NotNull BlockPos pos, @NotNull Node<NodeHolder> selfNode, @Nullable CenterWireConnectionFilter filter) {
-        List<Node<NodeHolder>> collector = new ArrayList<>();
+    public static @NotNull Collection<NodeHolder<BlockNode>> centerWireFindConnections(@NotNull CenterWireBlockNode self,
+                                                                                  @NotNull NodeHolder<BlockNode> selfNode,
+                                                                                  @NotNull ServerWorld world,
+                                                                                  @NotNull GraphView graphView,
+                                                                                  @Nullable CenterWireConnectionFilter filter) {
+        BlockPos pos = selfNode.getPos();
+        List<NodeHolder<BlockNode>> collector = new ArrayList<>();
 
         // add internal connections
-        graphView.getNodesAt(pos).filter(other -> centerWireCanConnect(self, world, pos, selfNode, other, filter))
+        graphView.getNodesAt(pos).filter(other -> centerWireCanConnect(self, selfNode, world, other, filter))
             .forEach(collector::add);
 
         // add external connections
         for (Direction external : Direction.values()) {
             graphView.getNodesAt(pos.offset(external))
-                .filter(other -> centerWireCanConnect(self, world, pos, selfNode, other, filter))
+                .filter(other -> centerWireCanConnect(self, selfNode, world, other, filter))
                 .forEach(collector::add);
         }
 
@@ -251,32 +243,32 @@ public final class WireConnectionDiscoverers {
      * Checks if this center-wire node can connect to the given node.
      *
      * @param self      this node.
-     * @param world     the block world to check the connection in.
-     * @param pos       this node's position.
      * @param selfNode  this node's holder.
+     * @param world     the block world to check the connection in.
      * @param otherNode the node that this node could potentially connect to.
      * @param filter    a general connection filter, used to filter connections.
      * @return <code>true</code> if this node can connect to the given node.
      */
-    public static boolean centerWireCanConnect(@NotNull CenterWireBlockNode self, @NotNull ServerWorld world,
-                                               @NotNull BlockPos pos, @NotNull Node<NodeHolder> selfNode,
-                                               @NotNull Node<NodeHolder> otherNode,
+    public static boolean centerWireCanConnect(@NotNull CenterWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode,
+                                               @NotNull ServerWorld world,
+                                               @NotNull NodeHolder<BlockNode> otherNode,
                                                @Nullable CenterWireConnectionFilter filter) {
-        BlockPos otherPos = otherNode.data().getPos();
-        BlockNode other = otherNode.data().getNode();
+        BlockPos pos = selfNode.getPos();
+        BlockPos otherPos = otherNode.getPos();
+        BlockNode other = otherNode.getNode();
 
         BlockPos posDiff = otherPos.subtract(pos);
         Direction posDiffDir = Direction.fromVector(posDiff);
 
         if (other instanceof CenterWireBlockNode || other instanceof FullWireBlockNode) {
             return posDiffDir != null &&
-                (filter == null || filter.canConnect(self, world, pos, posDiffDir, selfNode, otherNode)) &&
-                self.canConnect(world, pos, posDiffDir, selfNode, otherNode);
+                (filter == null || filter.canConnect(self, selfNode, world, posDiffDir, otherNode)) &&
+                self.canConnect(selfNode, world, posDiffDir, otherNode);
         } else if (other instanceof SidedWireBlockNode otherSided) {
             Direction otherSide = otherSided.getSide();
             return posDiffDir == null &&
-                (filter == null || filter.canConnect(self, world, pos, otherSide, selfNode, otherNode)) &&
-                self.canConnect(world, pos, otherSide, selfNode, otherNode);
+                (filter == null || filter.canConnect(self, selfNode, world, otherSide, otherNode)) &&
+                self.canConnect(selfNode, world, otherSide, otherNode);
         } else {
             // we only know how to handle connections to SidedWireBlockNodes, CenterWireBlockNodes, and FullWireBlockNodes for now
             return false;

--- a/src/main/java/com/kneelawk/graphlib/api/wire/WireConnectionFilter.java
+++ b/src/main/java/com/kneelawk/graphlib/api/wire/WireConnectionFilter.java
@@ -4,12 +4,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
 import com.kneelawk.graphlib.api.node.BlockNode;
-import com.kneelawk.graphlib.api.util.graph.Node;
 
 /**
  * More general wire connection filter, designed only to determine if two types of block nodes should be allowed to
@@ -26,16 +24,16 @@ public interface WireConnectionFilter extends FullWireConnectionFilter, SidedWir
     boolean accepts(@NotNull BlockNode self, @NotNull BlockNode other);
 
     @Override
-    default boolean canConnect(@NotNull FullWireBlockNode self, @NotNull ServerWorld world, @NotNull BlockPos pos,
+    default boolean canConnect(@NotNull FullWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode, @NotNull ServerWorld world,
                                @NotNull Direction onSide, @Nullable Direction wireSide,
-                               @NotNull Node<NodeHolder> selfNode, @NotNull Node<NodeHolder> otherNode) {
-        return accepts(self, otherNode.data().getNode());
+                               @NotNull NodeHolder<BlockNode> otherNode) {
+        return accepts(self, otherNode.getNode());
     }
 
     @Override
-    default boolean canConnect(@NotNull SidedWireBlockNode self, @NotNull ServerWorld world, @NotNull BlockPos pos,
+    default boolean canConnect(@NotNull SidedWireBlockNode self, @NotNull NodeHolder<BlockNode> selfNode, @NotNull ServerWorld world,
                                @NotNull Direction inDirection, @NotNull WireConnectionType connectionType,
-                               @NotNull Node<NodeHolder> selfNode, @NotNull Node<NodeHolder> otherNode) {
-        return accepts(self, otherNode.data().getNode());
+                               @NotNull NodeHolder<BlockNode> otherNode) {
+        return accepts(self, otherNode.getNode());
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/impl/client/GraphLibClientImpl.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/client/GraphLibClientImpl.java
@@ -18,11 +18,11 @@ import net.minecraft.util.math.ChunkPos;
 
 import com.kneelawk.graphlib.api.client.BlockNodePacketDecoder;
 import com.kneelawk.graphlib.api.client.GraphLibClient;
-import com.kneelawk.graphlib.impl.client.render.BlockNodeRendererHolder;
 import com.kneelawk.graphlib.impl.Constants;
 import com.kneelawk.graphlib.impl.client.graph.ClientBlockGraph;
 import com.kneelawk.graphlib.impl.client.graph.SimpleClientBlockNode;
 import com.kneelawk.graphlib.impl.client.graph.SimpleClientSidedBlockNode;
+import com.kneelawk.graphlib.impl.client.render.BlockNodeRendererHolder;
 import com.kneelawk.graphlib.impl.client.render.SimpleBlockNodeRenderer;
 import com.kneelawk.graphlib.impl.client.render.SimpleSidedBlockNodeRenderer;
 

--- a/src/main/java/com/kneelawk/graphlib/impl/client/GraphLibClientNetworking.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/client/GraphLibClientNetworking.java
@@ -23,8 +23,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Direction;
 
-import com.kneelawk.graphlib.api.client.ClientBlockNodeHolder;
 import com.kneelawk.graphlib.api.client.BlockNodePacketDecoder;
+import com.kneelawk.graphlib.api.client.ClientBlockNodeHolder;
 import com.kneelawk.graphlib.api.node.client.ClientBlockNode;
 import com.kneelawk.graphlib.api.util.graph.Graph;
 import com.kneelawk.graphlib.api.util.graph.Node;

--- a/src/main/java/com/kneelawk/graphlib/impl/command/GraphLibCommand.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/command/GraphLibCommand.java
@@ -5,7 +5,6 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.minecraft.command.CommandBuildContext;
 import net.minecraft.command.argument.BlockPosArgumentType;
-import net.minecraft.command.argument.IdentifierArgumentType;
 import net.minecraft.command.argument.RegistryEntryArgumentType;
 import net.minecraft.registry.Holder;
 import net.minecraft.server.command.ServerCommandSource;
@@ -16,7 +15,6 @@ import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.text.Texts;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Identifier;
 import net.minecraft.util.math.BlockPos;
 
 import com.kneelawk.graphlib.impl.Constants;

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleNodeConnection.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleNodeConnection.java
@@ -1,0 +1,46 @@
+package com.kneelawk.graphlib.impl.graph.simple;
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.kneelawk.graphlib.api.graph.NodeConnection;
+import com.kneelawk.graphlib.api.graph.NodeHolder;
+import com.kneelawk.graphlib.api.node.BlockNode;
+import com.kneelawk.graphlib.api.util.graph.Link;
+
+public class SimpleNodeConnection implements NodeConnection {
+    private final Link<SimpleNodeWrapper> link;
+
+    public SimpleNodeConnection(Link<SimpleNodeWrapper> link) {
+        this.link = link;
+    }
+
+    @Override
+    public @NotNull NodeHolder<BlockNode> getFirst() {
+        return new SimpleNodeHolder<>(link.first());
+    }
+
+    @Override
+    public @NotNull NodeHolder<BlockNode> getSecond() {
+        return new SimpleNodeHolder<>(link.second());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SimpleNodeConnection that = (SimpleNodeConnection) o;
+        return Objects.equals(link, that.link);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(link);
+    }
+
+    @Override
+    public String toString() {
+        return super.toString();
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleNodeWrapper.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleNodeWrapper.java
@@ -1,0 +1,103 @@
+package com.kneelawk.graphlib.impl.graph.simple;
+
+// Translated from 2xsaiko's HCTM-Base WireNetworkState code:
+// https://github.com/2xsaiko/hctm-base/blob/119df440743543b8b4979b450452d73f2c3c4c47/src/main/kotlin/common/wire/WireNetworkState.kt
+
+import java.util.Objects;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtElement;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
+
+import com.kneelawk.graphlib.api.node.BlockNode;
+import com.kneelawk.graphlib.api.node.BlockNodeDecoder;
+import com.kneelawk.graphlib.impl.GLLog;
+import com.kneelawk.graphlib.impl.graph.GraphUniverseImpl;
+
+public final class SimpleNodeWrapper {
+    final @NotNull BlockPos pos;
+    final @NotNull BlockNode node;
+
+    long graphId;
+
+    public SimpleNodeWrapper(@NotNull BlockPos pos, @NotNull BlockNode node, long graphId) {
+        this.pos = pos.toImmutable();
+        this.node = node;
+        this.graphId = graphId;
+    }
+
+    public @NotNull NbtCompound toTag() {
+        NbtCompound tag = new NbtCompound();
+
+        tag.putInt("x", pos.getX());
+        tag.putInt("y", pos.getY());
+        tag.putInt("z", pos.getZ());
+
+        NbtElement nodeTag = node.toTag();
+        if (nodeTag != null) {
+            tag.put("node", nodeTag);
+        }
+
+        tag.putString("type", node.getTypeId().toString());
+
+        return tag;
+    }
+
+    @Nullable
+    public static SimpleNodeWrapper fromTag(@NotNull GraphUniverseImpl universe, @NotNull NbtCompound tag,
+                                            long graphId) {
+        BlockPos pos = new BlockPos(tag.getInt("x"), tag.getInt("y"), tag.getInt("z"));
+
+        Identifier typeId = new Identifier(tag.getString("type"));
+        BlockNodeDecoder decoder = universe.getDecoder(typeId);
+
+        if (decoder == null) {
+            GLLog.warn("Tried to load unknown BlockNode type: {} @ {}", typeId, pos);
+            return null;
+        }
+
+        NbtElement nodeTag = tag.get("node");
+        BlockNode node = decoder.createBlockNodeFromTag(nodeTag);
+
+        if (node == null) {
+            GLLog.warn("Unable to decode BlockNode with type: {} @ {}", typeId, pos);
+            return null;
+        }
+
+        return new SimpleNodeWrapper(pos, node, graphId);
+    }
+
+    public @NotNull BlockPos getPos() {
+        return pos;
+    }
+
+    public @NotNull BlockNode getNode() {
+        return node;
+    }
+
+    public long getGraphId() {
+        return graphId;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (SimpleNodeWrapper) obj;
+        return Objects.equals(this.pos, that.pos) && Objects.equals(this.node, that.node);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(pos, node);
+    }
+
+    @Override
+    public String toString() {
+        return "BlockNodeWrapper[" + "pos=" + pos + ", " + "graphId=" + graphId + ", " + "node=" + node + ']';
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/impl/mixin/api/StorageHelper.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/mixin/api/StorageHelper.java
@@ -8,7 +8,6 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.world.storage.StorageIoWorker;
 
 import com.kneelawk.graphlib.impl.graph.GraphWorldStorage;
-import com.kneelawk.graphlib.impl.graph.simple.SimpleGraphWorld;
 import com.kneelawk.graphlib.impl.mixin.impl.StorageIoWorkerAccessor;
 
 public class StorageHelper {

--- a/src/main/java/com/kneelawk/graphlib/impl/util/ReadOnlyMappingCollection.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/util/ReadOnlyMappingCollection.java
@@ -1,0 +1,370 @@
+package com.kneelawk.graphlib.impl.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+
+public class ReadOnlyMappingCollection<T, R> implements Collection<R> {
+    private final Collection<T> delegate;
+    private final Function<T, R> mapper;
+
+    public ReadOnlyMappingCollection(Collection<T> delegate, Function<T, R> mapper) {
+        this.delegate = delegate;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Returns the number of elements in this collection.  If this collection
+     * contains more than {@code Integer.MAX_VALUE} elements, returns
+     * {@code Integer.MAX_VALUE}.
+     *
+     * @return the number of elements in this collection
+     */
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    /**
+     * Returns {@code true} if this collection contains no elements.
+     *
+     * @return {@code true} if this collection contains no elements
+     */
+    @Override
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    /**
+     * Returns {@code true} if this collection contains the specified element.
+     * More formally, returns {@code true} if and only if this collection
+     * contains at least one element {@code e} such that
+     * {@code Objects.equals(o, e)}.
+     *
+     * @param o element whose presence in this collection is to be tested
+     * @return {@code true} if this collection contains the specified
+     * element
+     * @throws ClassCastException   if the type of the specified element
+     *                              is incompatible with this collection
+     *                              (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException if the specified element is null and this
+     *                              collection does not permit null elements
+     *                              (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
+     */
+    @Override
+    public boolean contains(Object o) {
+        return delegate.contains(o);
+    }
+
+    /**
+     * Returns an iterator over the elements in this collection.  There are no
+     * guarantees concerning the order in which the elements are returned
+     * (unless this collection is an instance of some class that provides a
+     * guarantee).
+     *
+     * @return an {@code Iterator} over the elements in this collection
+     */
+    @NotNull
+    @Override
+    public Iterator<R> iterator() {
+        return new MappingIterator(delegate.iterator());
+    }
+
+    /**
+     * Returns an array containing all of the elements in this collection.
+     * If this collection makes any guarantees as to what order its elements
+     * are returned by its iterator, this method must return the elements in
+     * the same order. The returned array's {@linkplain Class#getComponentType
+     * runtime component type} is {@code Object}.
+     *
+     * <p>The returned array will be "safe" in that no references to it are
+     * maintained by this collection.  (In other words, this method must
+     * allocate a new array even if this collection is backed by an array).
+     * The caller is thus free to modify the returned array.
+     *
+     * @return an array, whose {@linkplain Class#getComponentType runtime component
+     * type} is {@code Object}, containing all of the elements in this collection
+     * @apiNote This method acts as a bridge between array-based and collection-based APIs.
+     * It returns an array whose runtime type is {@code Object[]}.
+     * Use {@link #toArray(Object[]) toArray(T[])} to reuse an existing
+     * array, or use {@link #toArray(IntFunction)} to control the runtime type
+     * of the array.
+     */
+    @NotNull
+    @Override
+    public Object @NotNull [] toArray() {
+        return delegate.stream().map(mapper).toArray();
+    }
+
+    /**
+     * Returns an array containing all of the elements in this collection;
+     * the runtime type of the returned array is that of the specified array.
+     * If the collection fits in the specified array, it is returned therein.
+     * Otherwise, a new array is allocated with the runtime type of the
+     * specified array and the size of this collection.
+     *
+     * <p>If this collection fits in the specified array with room to spare
+     * (i.e., the array has more elements than this collection), the element
+     * in the array immediately following the end of the collection is set to
+     * {@code null}.  (This is useful in determining the length of this
+     * collection <i>only</i> if the caller knows that this collection does
+     * not contain any {@code null} elements.)
+     *
+     * <p>If this collection makes any guarantees as to what order its elements
+     * are returned by its iterator, this method must return the elements in
+     * the same order.
+     *
+     * @param a the array into which the elements of this collection are to be
+     *          stored, if it is big enough; otherwise, a new array of the same
+     *          runtime type is allocated for this purpose.
+     * @return an array containing all of the elements in this collection
+     * @throws ArrayStoreException  if the runtime type of any element in this
+     *                              collection is not assignable to the {@linkplain Class#getComponentType
+     *                              runtime component type} of the specified array
+     * @throws NullPointerException if the specified array is null
+     * @apiNote This method acts as a bridge between array-based and collection-based APIs.
+     * It allows an existing array to be reused under certain circumstances.
+     * Use {@link #toArray()} to create an array whose runtime type is {@code Object[]},
+     * or use {@link #toArray(IntFunction)} to control the runtime type of
+     * the array.
+     *
+     * <p>Suppose {@code x} is a collection known to contain only strings.
+     * The following code can be used to dump the collection into a previously
+     * allocated {@code String} array:
+     *
+     * <pre>
+     *     String[] y = new String[SIZE];
+     *     ...
+     *     y = x.toArray(y);</pre>
+     *
+     * <p>The return value is reassigned to the variable {@code y}, because a
+     * new array will be allocated and returned if the collection {@code x} has
+     * too many elements to fit into the existing array {@code y}.
+     *
+     * <p>Note that {@code toArray(new Object[0])} is identical in function to
+     * {@code toArray()}.
+     */
+    @NotNull
+    @Override
+    public <A> A[] toArray(@NotNull A[] a) {
+        return delegate.stream().map(mapper).toList().toArray(a);
+    }
+
+    /**
+     * Ensures that this collection contains the specified element (optional
+     * operation).  Returns {@code true} if this collection changed as a
+     * result of the call.  (Returns {@code false} if this collection does
+     * not permit duplicates and already contains the specified element.)<p>
+     * <p>
+     * Collections that support this operation may place limitations on what
+     * elements may be added to this collection.  In particular, some
+     * collections will refuse to add {@code null} elements, and others will
+     * impose restrictions on the type of elements that may be added.
+     * Collection classes should clearly specify in their documentation any
+     * restrictions on what elements may be added.<p>
+     * <p>
+     * If a collection refuses to add a particular element for any reason
+     * other than that it already contains the element, it <i>must</i> throw
+     * an exception (rather than returning {@code false}).  This preserves
+     * the invariant that a collection always contains the specified element
+     * after this call returns.
+     *
+     * @param r element whose presence in this collection is to be ensured
+     * @return {@code true} if this collection changed as a result of the
+     * call
+     * @throws UnsupportedOperationException if the {@code add} operation
+     *                                       is not supported by this collection
+     * @throws ClassCastException            if the class of the specified element
+     *                                       prevents it from being added to this collection
+     * @throws NullPointerException          if the specified element is null and this
+     *                                       collection does not permit null elements
+     * @throws IllegalArgumentException      if some property of the element
+     *                                       prevents it from being added to this collection
+     * @throws IllegalStateException         if the element cannot be added at this
+     *                                       time due to insertion restrictions
+     */
+    @Override
+    public boolean add(R r) {
+        throw new UnsupportedOperationException("Collection is read-only");
+    }
+
+    /**
+     * Removes a single instance of the specified element from this
+     * collection, if it is present (optional operation).  More formally,
+     * removes an element {@code e} such that
+     * {@code Objects.equals(o, e)}, if
+     * this collection contains one or more such elements.  Returns
+     * {@code true} if this collection contained the specified element (or
+     * equivalently, if this collection changed as a result of the call).
+     *
+     * @param o element to be removed from this collection, if present
+     * @return {@code true} if an element was removed as a result of this call
+     * @throws ClassCastException            if the type of the specified element
+     *                                       is incompatible with this collection
+     *                                       (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException          if the specified element is null and this
+     *                                       collection does not permit null elements
+     *                                       (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
+     * @throws UnsupportedOperationException if the {@code remove} operation
+     *                                       is not supported by this collection
+     */
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException("Collection is read-only");
+    }
+
+    /**
+     * Returns {@code true} if this collection contains all of the elements
+     * in the specified collection.
+     *
+     * @param c collection to be checked for containment in this collection
+     * @return {@code true} if this collection contains all of the elements
+     * in the specified collection
+     * @throws ClassCastException   if the types of one or more elements
+     *                              in the specified collection are incompatible with this
+     *                              collection
+     *                              (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException if the specified collection contains one
+     *                              or more null elements and this collection does not permit null
+     *                              elements
+     *                              (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>),
+     *                              or if the specified collection is null.
+     * @see #contains(Object)
+     */
+    @Override
+    public boolean containsAll(@NotNull Collection<?> c) {
+        Set<R> set = delegate.stream().map(mapper).collect(Collectors.toSet());
+        return set.containsAll(c);
+    }
+
+    /**
+     * Adds all of the elements in the specified collection to this collection
+     * (optional operation).  The behavior of this operation is undefined if
+     * the specified collection is modified while the operation is in progress.
+     * (This implies that the behavior of this call is undefined if the
+     * specified collection is this collection, and this collection is
+     * nonempty.)
+     *
+     * @param c collection containing elements to be added to this collection
+     * @return {@code true} if this collection changed as a result of the call
+     * @throws UnsupportedOperationException if the {@code addAll} operation
+     *                                       is not supported by this collection
+     * @throws ClassCastException            if the class of an element of the specified
+     *                                       collection prevents it from being added to this collection
+     * @throws NullPointerException          if the specified collection contains a
+     *                                       null element and this collection does not permit null elements,
+     *                                       or if the specified collection is null
+     * @throws IllegalArgumentException      if some property of an element of the
+     *                                       specified collection prevents it from being added to this
+     *                                       collection
+     * @throws IllegalStateException         if not all the elements can be added at
+     *                                       this time due to insertion restrictions
+     * @see #add(Object)
+     */
+    @Override
+    public boolean addAll(@NotNull Collection<? extends R> c) {
+        throw new UnsupportedOperationException("Collection is read-only");
+    }
+
+    /**
+     * Removes all of this collection's elements that are also contained in the
+     * specified collection (optional operation).  After this call returns,
+     * this collection will contain no elements in common with the specified
+     * collection.
+     *
+     * @param c collection containing elements to be removed from this collection
+     * @return {@code true} if this collection changed as a result of the
+     * call
+     * @throws UnsupportedOperationException if the {@code removeAll} method
+     *                                       is not supported by this collection
+     * @throws ClassCastException            if the types of one or more elements
+     *                                       in this collection are incompatible with the specified
+     *                                       collection
+     *                                       (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException          if this collection contains one or more
+     *                                       null elements and the specified collection does not support
+     *                                       null elements
+     *                                       (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>),
+     *                                       or if the specified collection is null
+     * @see #remove(Object)
+     * @see #contains(Object)
+     */
+    @Override
+    public boolean removeAll(@NotNull Collection<?> c) {
+        throw new UnsupportedOperationException("Collection is read-only");
+    }
+
+    /**
+     * Retains only the elements in this collection that are contained in the
+     * specified collection (optional operation).  In other words, removes from
+     * this collection all of its elements that are not contained in the
+     * specified collection.
+     *
+     * @param c collection containing elements to be retained in this collection
+     * @return {@code true} if this collection changed as a result of the call
+     * @throws UnsupportedOperationException if the {@code retainAll} operation
+     *                                       is not supported by this collection
+     * @throws ClassCastException            if the types of one or more elements
+     *                                       in this collection are incompatible with the specified
+     *                                       collection
+     *                                       (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
+     * @throws NullPointerException          if this collection contains one or more
+     *                                       null elements and the specified collection does not permit null
+     *                                       elements
+     *                                       (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>),
+     *                                       or if the specified collection is null
+     * @see #remove(Object)
+     * @see #contains(Object)
+     */
+    @Override
+    public boolean retainAll(@NotNull Collection<?> c) {
+        throw new UnsupportedOperationException("Collection is read-only");
+    }
+
+    /**
+     * Removes all of the elements from this collection (optional operation).
+     * The collection will be empty after this method returns.
+     *
+     * @throws UnsupportedOperationException if the {@code clear} operation
+     *                                       is not supported by this collection
+     */
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("Collection is read-only");
+    }
+
+    private class MappingIterator implements Iterator<R> {
+        private final Iterator<T> input;
+
+        private MappingIterator(Iterator<T> input) {
+            this.input = input;
+        }
+
+        /**
+         * Returns {@code true} if the iteration has more elements.
+         * (In other words, returns {@code true} if {@link #next} would
+         * return an element rather than throwing an exception.)
+         *
+         * @return {@code true} if the iteration has more elements
+         */
+        @Override
+        public boolean hasNext() {
+            return input.hasNext();
+        }
+
+        /**
+         * Returns the next element in the iteration.
+         *
+         * @return the next element in the iteration
+         * @throws NoSuchElementException if the iteration has no more elements
+         */
+        @Override
+        public R next() {
+            return mapper.apply(input.next());
+        }
+    }
+}


### PR DESCRIPTION
# This PR
This PR removes *most* of the public API usage of `Node<>`s, replacing it with more usable `NodeHolder<>`s.

# Related Issues
This fixes #6.