### PR TITLE
Allow Graphs to Store Arbitrary Data

### DIFF
--- a/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
@@ -9,6 +9,8 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkSectionPos;
 
 import com.kneelawk.graphlib.api.graph.user.BlockNode;
+import com.kneelawk.graphlib.api.graph.user.GraphEntity;
+import com.kneelawk.graphlib.api.graph.user.GraphEntityType;
 import com.kneelawk.graphlib.api.graph.user.NodeEntity;
 import com.kneelawk.graphlib.api.graph.user.SidedBlockNode;
 import com.kneelawk.graphlib.api.util.NodePos;
@@ -71,6 +73,16 @@ public interface BlockGraph {
      * @return a stream of all the chunk sections this graph is in.
      */
     @NotNull Stream<ChunkSectionPos> getChunks();
+
+    /**
+     * Gets a graph entity attached to this graph.
+     *
+     * @param type the type of graph entity to retrieve.
+     * @param <G>  the type of graph entity to retrieve.
+     * @return the given graph entity attached to this graph.
+     * @throws IllegalArgumentException if the given graph entity type has not been registered with this graph's universe.
+     */
+    @NotNull <G extends GraphEntity<G>> G getGraphEntity(GraphEntityType<G> type);
 
     /**
      * Gets the number of nodes in this graph.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphEntityContext.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphEntityContext.java
@@ -1,0 +1,33 @@
+package com.kneelawk.graphlib.api.graph;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.server.world.ServerWorld;
+
+/**
+ * Context for a graph entity.
+ */
+public interface GraphEntityContext {
+    /**
+     * Marks this entity's graph as dirty and in need of saving.
+     */
+    void markDirty();
+
+    /**
+     * Gets the block world that this graph entity exists within.
+     * @return the block world that this graph entity exists within.
+     */
+    @NotNull ServerWorld getBlockWorld();
+
+    /**
+     * Gets the graph world that this graph entity exists within.
+     * @return the graph world that this graph entity exists within.
+     */
+    @NotNull GraphWorld getGraphWorld();
+
+    /**
+     * Gets the graph that this graph entity is associated with.
+     * @return the graph that this graph entity is associated with.
+     */
+    @NotNull BlockGraph getGraph();
+}

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphUniverse.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphUniverse.java
@@ -14,6 +14,7 @@ import net.minecraft.util.Identifier;
 import com.kneelawk.graphlib.api.graph.user.BlockNode;
 import com.kneelawk.graphlib.api.graph.user.BlockNodeDecoder;
 import com.kneelawk.graphlib.api.graph.user.BlockNodeDiscoverer;
+import com.kneelawk.graphlib.api.graph.user.GraphEntityType;
 import com.kneelawk.graphlib.api.graph.user.NodeEntity;
 import com.kneelawk.graphlib.api.graph.user.NodeEntityDecoder;
 import com.kneelawk.graphlib.api.world.SaveMode;
@@ -136,6 +137,27 @@ public interface GraphUniverse {
      * @param decoders the set of node entity decoders to be registered.
      */
     void addNodeEntityDecoders(@NotNull Map<Identifier, ? extends NodeEntityDecoder> decoders);
+
+    /**
+     * Registers a {@link GraphEntityType}.
+     *
+     * @param type the graph entity type to be registered.
+     */
+    void addGraphEntityType(@NotNull GraphEntityType<?> type);
+
+    /**
+     * Registers a set of {@link GraphEntityType}s.
+     *
+     * @param types the graph entity types to be registered.
+     */
+    void addGraphEntityTypes(@NotNull GraphEntityType<?>... types);
+
+    /**
+     * Registers a set of {@link GraphEntityType}s.
+     *
+     * @param types the graph entity types to be registered.
+     */
+    void addGraphEntityTypes(@NotNull Iterable<GraphEntityType<?>> types);
 
     /**
      * Registers this graph universe so that it can be found by its id.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntity.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntity.java
@@ -1,0 +1,78 @@
+package com.kneelawk.graphlib.api.graph.user;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.nbt.NbtElement;
+
+import com.kneelawk.graphlib.api.graph.NodeHolder;
+
+/**
+ * Arbitrary data that can be stored in a graph.
+ */
+public interface GraphEntity<G extends GraphEntity<G>> {
+    /**
+     * Gets this graph entity's type.
+     *
+     * @return this graph entity's type.
+     */
+    @NotNull GraphEntityType<?> getType();
+
+    /**
+     * Encodes this graph entity as an NBT tag.
+     *
+     * @return this graph entity as an NBT tag.
+     */
+    @Nullable NbtElement toTag();
+
+    /**
+     * Called right before this entity's associated graph is deleted.
+     */
+    void onDestroy();
+
+    /**
+     * Called right before this entity's associated graph is unloaded.
+     * <p>
+     * Note: This cannot cancel graph unloading, however, any changes made here will be saved.
+     */
+    void onUnload();
+
+    /**
+     * Called when a new node is added to the graph.
+     *
+     * @param node       the new node added to the graph.
+     * @param nodeEntity the node's entity, if any.
+     */
+    void onNodeCreated(@NotNull NodeHolder<BlockNode> node, @Nullable NodeEntity nodeEntity);
+
+    /**
+     * Called when a node in this graph is destroyed.
+     *
+     * @param node       the node destroyed.
+     * @param nodeEntity the node's entity, if any.
+     */
+    void onNodeDestroyed(@NotNull NodeHolder<BlockNode> node, @Nullable NodeEntity nodeEntity);
+
+    /**
+     * Called when two nodes in the graph are linked.
+     *
+     * @param a the first node in the link.
+     * @param b the second node in the link.
+     */
+    void onLink(@NotNull NodeHolder<BlockNode> a, @NotNull NodeHolder<BlockNode> b);
+
+    /**
+     * Called when two nodes in the graph ar unlinked.
+     *
+     * @param a the first node in the link.
+     * @param b the second node in the link.
+     */
+    void onUnlink(@NotNull NodeHolder<BlockNode> a, @NotNull NodeHolder<BlockNode> b);
+
+    /**
+     * Merges another graph entity into this one.
+     *
+     * @param other the graph entity to be merged into this one.
+     */
+    void merge(@NotNull G other);
+}

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntity.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntity.java
@@ -9,6 +9,8 @@ import com.kneelawk.graphlib.api.graph.NodeHolder;
 
 /**
  * Arbitrary data that can be stored in a graph.
+ *
+ * @param <G> this graph entity class.
  */
 public interface GraphEntity<G extends GraphEntity<G>> {
     /**

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntityDecoder.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntityDecoder.java
@@ -1,0 +1,25 @@
+package com.kneelawk.graphlib.api.graph.user;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.nbt.NbtElement;
+
+import com.kneelawk.graphlib.api.graph.GraphEntityContext;
+
+/**
+ * Decodes a graph entity from an NBT tag.
+ *
+ * @param <G> the type of graph entity to decode.
+ */
+@FunctionalInterface
+public interface GraphEntityDecoder<G extends GraphEntity<G>> {
+    /**
+     * Decodes a graph entity from an NBT tag.
+     *
+     * @param tag the NBT tag to decode from.
+     * @param ctx the graph entity context for the new graph entity.
+     * @return a newly decoded graph entity, or <code>null</code> if no graph entity could be decoded.
+     */
+    @Nullable G decode(@Nullable NbtElement tag, @NotNull GraphEntityContext ctx);
+}

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntityFactory.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntityFactory.java
@@ -1,0 +1,21 @@
+package com.kneelawk.graphlib.api.graph.user;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.kneelawk.graphlib.api.graph.GraphEntityContext;
+
+/**
+ * Creates new graph entities.
+ *
+ * @param <G> the type of graph entity this factory creates.
+ */
+@FunctionalInterface
+public interface GraphEntityFactory<G extends GraphEntity<G>> {
+    /**
+     * Creates a new graph entity.
+     *
+     * @param ctx the graph entity context for this graph entity.
+     * @return a newly created graph entity.
+     */
+    @NotNull G createNew(@NotNull GraphEntityContext ctx);
+}

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntitySplitter.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntitySplitter.java
@@ -1,0 +1,24 @@
+package com.kneelawk.graphlib.api.graph.user;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.kneelawk.graphlib.api.graph.BlockGraph;
+import com.kneelawk.graphlib.api.graph.GraphEntityContext;
+
+/**
+ * Splits a new graph entity off of an existing graph entity.
+ *
+ * @param <G> the type of graph this splitter handles.
+ */
+@FunctionalInterface
+public interface GraphEntitySplitter<G extends GraphEntity<G>> {
+    /**
+     * Splits a new graph entity off of an existing graph entity.
+     *
+     * @param original      the original graph entity.
+     * @param originalGraph the graph of the original graph entity.
+     * @param ctx           the graph entity context of the new graph entity. Note: this contains a reference to the new graph.
+     * @return a newly created graph entity split off of the original graph entity.
+     */
+    @NotNull G splitNew(@NotNull G original, @NotNull BlockGraph originalGraph, @NotNull GraphEntityContext ctx);
+}

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntityType.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/GraphEntityType.java
@@ -1,0 +1,67 @@
+package com.kneelawk.graphlib.api.graph.user;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.util.Identifier;
+
+import com.kneelawk.graphlib.api.graph.BlockGraph;
+import com.kneelawk.graphlib.api.graph.GraphEntityContext;
+
+/**
+ * Holds info about a type of graph entity.
+ *
+ * @param id       the id of the graph entity type.
+ * @param factory  a factory for creating new graph entities of this type.
+ * @param decoder  a decoder for decoding graph entities of this type.
+ * @param splitter a splitter for splitting graph entities of this type apart.
+ * @param <G>      the type of graph entity this corresponds to.
+ */
+public record GraphEntityType<G extends GraphEntity<G>>(@NotNull Identifier id, @NotNull GraphEntityFactory<G> factory,
+                                                        @NotNull GraphEntityDecoder<G> decoder,
+                                                        @NotNull GraphEntitySplitter<G> splitter) {
+    /**
+     * Used for merging one graph entity into another.
+     * <p>
+     * This does the necessary casts for the java compiler to be happy.
+     *
+     * @param into the graph entity that the other entity is being merged into.
+     * @param from the graph entity that is being merged into the other entity.
+     */
+    @ApiStatus.Internal
+    @SuppressWarnings("unchecked")
+    public void merge(GraphEntity<?> into, GraphEntity<?> from) {
+        ((G) into).merge((G) from);
+    }
+
+    /**
+     * Used for calling the splitter with the correct arguments.
+     *
+     * @param original      the original graph entity.
+     * @param originalGraph the graph the original graph entity is associated with.
+     * @param ctx           the graph context for the new graph entity.
+     * @return a newly split off graph entity.
+     */
+    @ApiStatus.Internal
+    @SuppressWarnings("unchecked")
+    public @NotNull GraphEntity<G> splitNew(@NotNull GraphEntity<?> original, @NotNull BlockGraph originalGraph,
+                                            @NotNull GraphEntityContext ctx) {
+        return splitter.splitNew((G) original, originalGraph, ctx);
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GraphEntityType<?> that = (GraphEntityType<?>) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/GraphUniverseImpl.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/GraphUniverseImpl.java
@@ -13,6 +13,7 @@ import net.minecraft.util.math.BlockPos;
 import com.kneelawk.graphlib.api.graph.GraphUniverse;
 import com.kneelawk.graphlib.api.graph.user.BlockNode;
 import com.kneelawk.graphlib.api.graph.user.BlockNodeDecoder;
+import com.kneelawk.graphlib.api.graph.user.GraphEntityType;
 import com.kneelawk.graphlib.api.graph.user.NodeEntityDecoder;
 
 public interface GraphUniverseImpl extends GraphUniverse {
@@ -26,4 +27,8 @@ public interface GraphUniverseImpl extends GraphUniverse {
     @Nullable BlockNodeDecoder getNodeDecoder(@NotNull Identifier typeId);
 
     @Nullable NodeEntityDecoder getNodeEntityDecoder(@NotNull Identifier typeId);
+
+    @Nullable GraphEntityType<?> getGraphEntityType(@NotNull Identifier typeId);
+
+    @NotNull Iterable<GraphEntityType<?>> getAllGraphEntityTypes();
 }

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphEntityContext.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphEntityContext.java
@@ -1,0 +1,31 @@
+package com.kneelawk.graphlib.impl.graph.simple;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.minecraft.server.world.ServerWorld;
+
+import com.kneelawk.graphlib.api.graph.BlockGraph;
+import com.kneelawk.graphlib.api.graph.GraphEntityContext;
+import com.kneelawk.graphlib.api.graph.GraphWorld;
+
+public record SimpleGraphEntityContext(ServerWorld blockWorld, SimpleGraphWorld graphWorld, BlockGraph graph) implements GraphEntityContext {
+    @Override
+    public void markDirty() {
+        graphWorld.markDirty(graph.getId());
+    }
+
+    @Override
+    public @NotNull ServerWorld getBlockWorld() {
+        return blockWorld;
+    }
+
+    @Override
+    public @NotNull GraphWorld getGraphWorld() {
+        return graphWorld;
+    }
+
+    @Override
+    public @NotNull BlockGraph getGraph() {
+        return graph;
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphUniverse.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphUniverse.java
@@ -26,6 +26,7 @@ import com.kneelawk.graphlib.api.graph.GraphUniverse;
 import com.kneelawk.graphlib.api.graph.user.BlockNode;
 import com.kneelawk.graphlib.api.graph.user.BlockNodeDecoder;
 import com.kneelawk.graphlib.api.graph.user.BlockNodeDiscoverer;
+import com.kneelawk.graphlib.api.graph.user.GraphEntityType;
 import com.kneelawk.graphlib.api.graph.user.NodeEntityDecoder;
 import com.kneelawk.graphlib.api.util.ColorUtils;
 import com.kneelawk.graphlib.api.world.SaveMode;
@@ -40,6 +41,7 @@ public class SimpleGraphUniverse implements GraphUniverse, GraphUniverseImpl {
     private final Map<Identifier, BlockNodeDecoder> nodeDecoders = new LinkedHashMap<>();
     private final Object2IntMap<Identifier> typeIndices = new Object2IntLinkedOpenHashMap<>();
     private final Map<Identifier, NodeEntityDecoder> nodeEntityDecoders = new LinkedHashMap<>();
+    private final Map<Identifier, GraphEntityType<?>> graphEntityTypes = new LinkedHashMap<>();
     final SaveMode saveMode;
 
     public SimpleGraphUniverse(Identifier universeId, SimpleGraphUniverseBuilder builder) {
@@ -124,6 +126,25 @@ public class SimpleGraphUniverse implements GraphUniverse, GraphUniverseImpl {
     }
 
     @Override
+    public void addGraphEntityType(@NotNull GraphEntityType<?> type) {
+        this.graphEntityTypes.put(type.id(), type);
+    }
+
+    @Override
+    public void addGraphEntityTypes(@NotNull GraphEntityType<?>... types) {
+        for (GraphEntityType<?> type : types) {
+            this.graphEntityTypes.put(type.id(), type);
+        }
+    }
+
+    @Override
+    public void addGraphEntityTypes(@NotNull Iterable<GraphEntityType<?>> types) {
+        for (GraphEntityType<?> type : types) {
+            this.graphEntityTypes.put(type.id(), type);
+        }
+    }
+
+    @Override
     public void register() {
         GraphLibImpl.register(this);
     }
@@ -153,5 +174,15 @@ public class SimpleGraphUniverse implements GraphUniverse, GraphUniverseImpl {
     @Override
     public @Nullable NodeEntityDecoder getNodeEntityDecoder(@NotNull Identifier typeId) {
         return nodeEntityDecoders.get(typeId);
+    }
+
+    @Override
+    public @Nullable GraphEntityType<?> getGraphEntityType(@NotNull Identifier typeId) {
+        return graphEntityTypes.get(typeId);
+    }
+
+    @Override
+    public @NotNull Iterable<GraphEntityType<?>> getAllGraphEntityTypes() {
+        return graphEntityTypes.values();
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphWorld.java
@@ -472,8 +472,8 @@ public class SimpleGraphWorld implements AutoCloseable, GraphView, GraphWorld, G
      *
      * @return the newly-created graph.
      */
-    @NotNull SimpleBlockGraph createGraph() {
-        SimpleBlockGraph graph = new SimpleBlockGraph(this, getNextGraphId());
+    @NotNull SimpleBlockGraph createGraph(boolean initializeGraphEntities) {
+        SimpleBlockGraph graph = new SimpleBlockGraph(this, getNextGraphId(), initializeGraphEntities);
         loadedGraphs.put(graph.getId(), graph);
 
         // Fire graph created event
@@ -625,7 +625,7 @@ public class SimpleGraphWorld implements AutoCloseable, GraphView, GraphWorld, G
                 continue;
             }
 
-            SimpleBlockGraph newGraph = createGraph();
+            SimpleBlockGraph newGraph = createGraph(true);
             NodeHolder<BlockNode> node = newGraph.createNode(pos, bn, bn::createNodeEntity);
             updateNodeConnections(node);
         }
@@ -892,6 +892,8 @@ public class SimpleGraphWorld implements AutoCloseable, GraphView, GraphWorld, G
                     ChunkSectionPos.from(sectionPos));
             }
         }
+
+        graph.onDestroy();
     }
 
     private void markStateDirty() {


### PR DESCRIPTION
# This PR
This PR adds `GraphEntity`s, which are stored in a block graph and can store arbitrary data. These graph entities receive updates when the graph is updated, are split when the graph is split, and are merged when the graph is merged.

# Associated Issues
* This fixes #19.