### PR TITLE
Manual Links

### DIFF
--- a/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
@@ -12,6 +12,7 @@ import com.kneelawk.graphlib.api.graph.user.BlockNode;
 import com.kneelawk.graphlib.api.graph.user.GraphEntity;
 import com.kneelawk.graphlib.api.graph.user.GraphEntityType;
 import com.kneelawk.graphlib.api.graph.user.LinkEntity;
+import com.kneelawk.graphlib.api.graph.user.LinkKey;
 import com.kneelawk.graphlib.api.graph.user.NodeEntity;
 import com.kneelawk.graphlib.api.graph.user.SidedBlockNode;
 import com.kneelawk.graphlib.api.util.LinkPos;
@@ -46,11 +47,36 @@ public interface BlockGraph {
     @NotNull Stream<NodeHolder<SidedBlockNode>> getNodesAt(@NotNull SidedPos pos);
 
     /**
+     * Checks whether the given node actually exists in this graph.
+     *
+     * @param pos the position of the node to check.
+     * @return <code>true</code> if the given node actually exists.
+     */
+    boolean nodeExistsAt(@NotNull NodePos pos);
+
+    /**
      * Gets the node holder at a specific position.
+     *
      * @param pos the position of the node to get.
      * @return the node holder at the given position.
      */
     @Nullable NodeHolder<BlockNode> getNodeAt(@NotNull NodePos pos);
+
+    /**
+     * Checks whether the given link actually exists in this graph.
+     *
+     * @param pos the position of the link to check.
+     * @return <code>true</code> if the given link actually exists.
+     */
+    boolean linkExistsAt(@NotNull LinkPos pos);
+
+    /**
+     * Gets the link holder at the given position, if it exists.
+     *
+     * @param pos the position to get the link at.
+     * @return the link holder at the given position, if it exists.
+     */
+    @Nullable LinkHolder<LinkKey> getLinkAt(@NotNull LinkPos pos);
 
     /**
      * Gets the node entity at a given pos, if it exists.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
@@ -46,6 +46,13 @@ public interface BlockGraph {
     @NotNull Stream<NodeHolder<SidedBlockNode>> getNodesAt(@NotNull SidedPos pos);
 
     /**
+     * Gets the node holder at a specific position.
+     * @param pos the position of the node to get.
+     * @return the node holder at the given position.
+     */
+    @Nullable NodeHolder<BlockNode> getNodeAt(@NotNull NodePos pos);
+
+    /**
      * Gets the node entity at a given pos, if it exists.
      *
      * @param pos the position to find the node entity at.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
@@ -47,6 +47,14 @@ public interface GraphView {
     @NotNull Stream<NodeHolder<SidedBlockNode>> getNodesAt(@NotNull SidedPos pos);
 
     /**
+     * Gets the node holder at the given position.
+     *
+     * @param pos the position to get the node at.
+     * @return the node holder at the given position, if any.
+     */
+    @Nullable NodeHolder<BlockNode> getNodeAt(@NotNull NodePos pos);
+
+    /**
      * Checks whether the given node with the given position exists.
      *
      * @param pos the positioned node to try to find.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphView.java
@@ -13,6 +13,7 @@ import net.minecraft.util.math.ChunkSectionPos;
 
 import com.kneelawk.graphlib.api.graph.user.BlockNode;
 import com.kneelawk.graphlib.api.graph.user.LinkEntity;
+import com.kneelawk.graphlib.api.graph.user.LinkKey;
 import com.kneelawk.graphlib.api.graph.user.NodeEntity;
 import com.kneelawk.graphlib.api.graph.user.SidedBlockNode;
 import com.kneelawk.graphlib.api.util.LinkPos;
@@ -77,6 +78,22 @@ public interface GraphView {
      * @return the node entity at the given position, if it exists.
      */
     @Nullable NodeEntity getNodeEntity(@NotNull NodePos pos);
+
+    /**
+     * Checks whether the given link exists.
+     *
+     * @param pos the position of the link to check.
+     * @return <code>true</code> if the given link exists.
+     */
+    boolean linkExistsAt(@NotNull LinkPos pos);
+
+    /**
+     * Gets the link holder at the given position, if it exists.
+     *
+     * @param pos the position of the link to get.
+     * @return the link holder at the given position, if it exists.
+     */
+    @Nullable LinkHolder<LinkKey> getLinkAt(@NotNull LinkPos pos);
 
     /**
      * Gets the link entity at the given position, if it exists.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
@@ -25,6 +25,20 @@ public interface GraphWorld extends GraphView {
      * @param a             the first node to be connected.
      * @param b             the second node to be connected.
      * @param key           the key of the connection.
+     */
+    default void connectNodes(NodePos a, NodePos b, LinkKey key) {
+        connectNodes(a, b, key, key::createLinkEntity);
+    }
+
+    /**
+     * Connects two nodes to each other.
+     * <p>
+     * Note: in order for manually connected links to not be removed when the connected nodes are updated,
+     * {@link LinkKey#isAutomaticRemoval(LinkContext)} should return <code>false</code> for the given key.
+     *
+     * @param a             the first node to be connected.
+     * @param b             the second node to be connected.
+     * @param key           the key of the connection.
      * @param entityFactory a factory for potentially creating the link's entity.
      */
     void connectNodes(NodePos a, NodePos b, LinkKey key, LinkEntityFactory entityFactory);

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
@@ -3,6 +3,7 @@ package com.kneelawk.graphlib.api.graph;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import net.minecraft.util.math.BlockPos;
 
@@ -22,12 +23,13 @@ public interface GraphWorld extends GraphView {
      * Note: in order for manually connected links to not be removed when the connected nodes are updated,
      * {@link LinkKey#isAutomaticRemoval(LinkContext)} should return <code>false</code> for the given key.
      *
-     * @param a             the first node to be connected.
-     * @param b             the second node to be connected.
-     * @param key           the key of the connection.
+     * @param a   the first node to be connected.
+     * @param b   the second node to be connected.
+     * @param key the key of the connection.
+     * @return the link created, or <code>null</code> if no link could be created.
      */
-    default void connectNodes(NodePos a, NodePos b, LinkKey key) {
-        connectNodes(a, b, key, key::createLinkEntity);
+    default @Nullable LinkHolder<LinkKey> connectNodes(NodePos a, NodePos b, LinkKey key) {
+        return connectNodes(a, b, key, key::createLinkEntity);
     }
 
     /**
@@ -40,8 +42,9 @@ public interface GraphWorld extends GraphView {
      * @param b             the second node to be connected.
      * @param key           the key of the connection.
      * @param entityFactory a factory for potentially creating the link's entity.
+     * @return the link created, or <code>null</code> if no link could be created.
      */
-    void connectNodes(NodePos a, NodePos b, LinkKey key, LinkEntityFactory entityFactory);
+    @Nullable LinkHolder<LinkKey> connectNodes(NodePos a, NodePos b, LinkKey key, LinkEntityFactory entityFactory);
 
     /**
      * Disconnects two nodes from each other.
@@ -49,8 +52,9 @@ public interface GraphWorld extends GraphView {
      * @param a   the first node to be disconnected.
      * @param b   the second node to be disconnected.
      * @param key the key of the connection.
+     * @return <code>true</code> if a link was actually removed, <code>false</code> otherwise.
      */
-    void disconnectNodes(NodePos a, NodePos b, LinkKey key);
+    boolean disconnectNodes(NodePos a, NodePos b, LinkKey key);
 
     /**
      * Notifies the controller that a block-position has been changed and may need to have its nodes and connections

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
@@ -18,6 +18,9 @@ public interface GraphWorld extends GraphView {
 
     /**
      * Connects two nodes to each other.
+     * <p>
+     * Note: in order for manually connected links to not be removed when the connected nodes are updated,
+     * {@link LinkKey#isAutomaticRemoval(LinkContext)} should return <code>false</code> for the given key.
      *
      * @param a             the first node to be connected.
      * @param b             the second node to be connected.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
@@ -9,6 +9,7 @@ import net.minecraft.util.math.BlockPos;
 
 import com.kneelawk.graphlib.api.graph.user.LinkEntityFactory;
 import com.kneelawk.graphlib.api.graph.user.LinkKey;
+import com.kneelawk.graphlib.api.util.EmptyLinkKey;
 import com.kneelawk.graphlib.api.util.NodePos;
 import com.kneelawk.graphlib.api.util.SidedPos;
 
@@ -16,6 +17,20 @@ import com.kneelawk.graphlib.api.util.SidedPos;
  * Holds and manages all block graphs for a given world.
  */
 public interface GraphWorld extends GraphView {
+
+    /**
+     * Connects two nodes to each other.
+     * <p>
+     * Note: in order for manually connected links to not be removed when the connected nodes are updated,
+     * {@link LinkKey#isAutomaticRemoval(LinkContext)} should return <code>false</code> for the given key.
+     *
+     * @param a the first node to be connected.
+     * @param b the second node to be connected.
+     * @return the link created, or <code>null</code> if no link could be created.
+     */
+    default @Nullable LinkHolder<LinkKey> connectNodes(NodePos a, NodePos b) {
+        return connectNodes(a, b, EmptyLinkKey.INSTANCE, EmptyLinkKey.INSTANCE::createLinkEntity);
+    }
 
     /**
      * Connects two nodes to each other.
@@ -45,6 +60,17 @@ public interface GraphWorld extends GraphView {
      * @return the link created, or <code>null</code> if no link could be created.
      */
     @Nullable LinkHolder<LinkKey> connectNodes(NodePos a, NodePos b, LinkKey key, LinkEntityFactory entityFactory);
+
+    /**
+     * Disconnects two nodes from each other.
+     *
+     * @param a the first node to be disconnected.
+     * @param b the second node to be disconnected.
+     * @return <code>true</code> if a link was actually removed, <code>false</code> otherwise.
+     */
+    default boolean disconnectNodes(NodePos a, NodePos b) {
+        return disconnectNodes(a, b, EmptyLinkKey.INSTANCE);
+    }
 
     /**
      * Disconnects two nodes from each other.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphWorld.java
@@ -6,12 +6,34 @@ import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.util.math.BlockPos;
 
+import com.kneelawk.graphlib.api.graph.user.LinkEntityFactory;
+import com.kneelawk.graphlib.api.graph.user.LinkKey;
+import com.kneelawk.graphlib.api.util.NodePos;
 import com.kneelawk.graphlib.api.util.SidedPos;
 
 /**
  * Holds and manages all block graphs for a given world.
  */
 public interface GraphWorld extends GraphView {
+
+    /**
+     * Connects two nodes to each other.
+     *
+     * @param a             the first node to be connected.
+     * @param b             the second node to be connected.
+     * @param key           the key of the connection.
+     * @param entityFactory a factory for potentially creating the link's entity.
+     */
+    void connectNodes(NodePos a, NodePos b, LinkKey key, LinkEntityFactory entityFactory);
+
+    /**
+     * Disconnects two nodes from each other.
+     *
+     * @param a   the first node to be disconnected.
+     * @param b   the second node to be disconnected.
+     * @param key the key of the connection.
+     */
+    void disconnectNodes(NodePos a, NodePos b, LinkKey key);
 
     /**
      * Notifies the controller that a block-position has been changed and may need to have its nodes and connections

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/LinkEntityFactory.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/LinkEntityFactory.java
@@ -1,0 +1,19 @@
+package com.kneelawk.graphlib.api.graph.user;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.kneelawk.graphlib.api.graph.LinkEntityContext;
+
+/**
+ * Used for creating a new link entity.
+ */
+public interface LinkEntityFactory {
+    /**
+     * Creates a new link entity.
+     *
+     * @param ctx the link entity context for the new link entity.
+     * @return a new link entity, if one can be created.
+     */
+    @Nullable LinkEntity createNew(@NotNull LinkEntityContext ctx);
+}

--- a/src/main/java/com/kneelawk/graphlib/api/graph/user/LinkKey.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/user/LinkKey.java
@@ -8,6 +8,8 @@ import net.minecraft.util.Identifier;
 
 import com.kneelawk.graphlib.api.graph.LinkContext;
 import com.kneelawk.graphlib.api.graph.LinkEntityContext;
+import com.kneelawk.graphlib.api.graph.NodeContext;
+import com.kneelawk.graphlib.api.util.HalfLink;
 
 /**
  * The data stored in a link between nodes.
@@ -48,6 +50,26 @@ public interface LinkKey {
      */
     default @Nullable LinkEntity createLinkEntity(@NotNull LinkEntityContext ctx) {
         return null;
+    }
+
+    /**
+     * Checks whether this link should be automatically removed if either node doesn't want it anymore.
+     * <p>
+     * Automatic removal follows the rules:
+     * <ul>
+     *     <li>If a link does not appear in the result of {@link BlockNode#findConnections(NodeContext)}, then the link
+     *     is removed.</li>
+     *     <li>If either end's {@link BlockNode#canConnect(NodeContext, HalfLink)} returns <code>false</code>, the the
+     *     link is removed.</li>
+     * </ul>
+     * <p>
+     * Note: links are still automatically removed if the node at one end doesn't exist anymore.
+     *
+     * @param ctx the link context for this link.
+     * @return <code>true</code> if this node should be automatically removed.
+     */
+    default boolean isAutomaticRemoval(@NotNull LinkContext ctx) {
+        return true;
     }
 
     /**

--- a/src/main/java/com/kneelawk/graphlib/api/util/graph/Graph.java
+++ b/src/main/java/com/kneelawk/graphlib/api/util/graph/Graph.java
@@ -162,11 +162,11 @@ public final class Graph<T, L> implements Iterable<Node<T, L>> {
      * @param a       the first node to unlink.
      * @param b       the second node to unlink.
      * @param linkKey the key of the link to be removed.
+     * @return <code>true</code> if a link was removed from both nodes, <code>false</code> otherwise.
      */
-    public void unlink(@NotNull Node<T, L> a, @NotNull Node<T, L> b, @NotNull L linkKey) {
+    public boolean unlink(@NotNull Node<T, L> a, @NotNull Node<T, L> b, @NotNull L linkKey) {
         Link<T, L> link1 = new Link<>(a, b, linkKey);
-        a.onUnlink(link1);
-        b.onUnlink(link1);
+        return a.onUnlink(link1) & b.onUnlink(link1);
     }
 
     /**

--- a/src/main/java/com/kneelawk/graphlib/api/util/graph/Node.java
+++ b/src/main/java/com/kneelawk/graphlib/api/util/graph/Node.java
@@ -68,9 +68,10 @@ public final class Node<T, L> {
      * Adds the given link as a connection this node has.
      *
      * @param link the link between this node and another node.
+     * @return <code>true</code> if the link did not already exist.
      */
-    public void onLink(@NotNull Link<T, L> link) {
-        connections.add(link);
+    public boolean onLink(@NotNull Link<T, L> link) {
+        return connections.add(link);
     }
 
     /**
@@ -80,9 +81,10 @@ public final class Node<T, L> {
      * has actually been removed.
      *
      * @param link the link to remove.
+     * @return <code>true</code> if the link existed before being removed.
      */
-    public void onUnlink(@NotNull Link<T, L> link) {
-        connections.remove(link);
+    public boolean onUnlink(@NotNull Link<T, L> link) {
+        return connections.remove(link);
     }
 
     @Override

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleBlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleBlockGraph.java
@@ -33,7 +33,6 @@ import net.minecraft.util.math.ChunkSectionPos;
 import com.kneelawk.graphlib.api.event.GraphLibEvents;
 import com.kneelawk.graphlib.api.graph.BlockGraph;
 import com.kneelawk.graphlib.api.graph.LinkContext;
-import com.kneelawk.graphlib.api.graph.LinkEntityContext;
 import com.kneelawk.graphlib.api.graph.LinkHolder;
 import com.kneelawk.graphlib.api.graph.NodeContext;
 import com.kneelawk.graphlib.api.graph.NodeEntityContext;
@@ -43,6 +42,7 @@ import com.kneelawk.graphlib.api.graph.user.GraphEntity;
 import com.kneelawk.graphlib.api.graph.user.GraphEntityType;
 import com.kneelawk.graphlib.api.graph.user.LinkEntity;
 import com.kneelawk.graphlib.api.graph.user.LinkEntityDecoder;
+import com.kneelawk.graphlib.api.graph.user.LinkEntityFactory;
 import com.kneelawk.graphlib.api.graph.user.LinkKey;
 import com.kneelawk.graphlib.api.graph.user.LinkKeyDecoder;
 import com.kneelawk.graphlib.api.graph.user.NodeEntity;
@@ -123,7 +123,7 @@ public class SimpleBlockGraph implements BlockGraph {
                     }
                 }
 
-                Function<LinkEntityContext, @Nullable LinkEntity> entityFactory = key::createLinkEntity;
+                LinkEntityFactory entityFactory = key::createLinkEntity;
                 if (linkTag.contains("entityType", NbtElement.STRING_TYPE)) {
                     Identifier entityTypeId = new Identifier(linkTag.getString("entityType"));
                     LinkEntityDecoder decoder = controller.universe.getLinkEntityDecoder(entityTypeId);
@@ -166,7 +166,8 @@ public class SimpleBlockGraph implements BlockGraph {
     private final Graph<SimpleNodeWrapper, LinkKey> graph = new Graph<>();
     private final Map<NodePos, NodeEntity> nodeEntities = new Object2ObjectLinkedOpenHashMap<>();
     private final Map<LinkPos, LinkEntity> linkEntities = new Object2ObjectLinkedOpenHashMap<>();
-    private final Multimap<BlockPos, SimpleNodeHolder<BlockNode>> nodesInPos = LinkedHashMultimap.create();
+    private final Multimap<BlockPos, NodeHolder<BlockNode>> nodesInPos = LinkedHashMultimap.create();
+    private final Map<NodePos, NodeHolder<BlockNode>> nodesToHolders = new Object2ObjectLinkedOpenHashMap<>();
     final LongSet chunks = new LongLinkedOpenHashSet();
     private final Map<Class<?>, List<?>> nodeTypeCache = new HashMap<>();
     private final Map<GraphEntityType<?>, GraphEntity<?>> graphEntities = new Object2ObjectLinkedOpenHashMap<>();
@@ -307,7 +308,7 @@ public class SimpleBlockGraph implements BlockGraph {
      */
     @Override
     public @NotNull Stream<NodeHolder<BlockNode>> getNodesAt(@NotNull BlockPos pos) {
-        return nodesInPos.get(pos).stream().map(Function.identity());
+        return nodesInPos.get(pos).stream();
     }
 
     /**
@@ -321,6 +322,17 @@ public class SimpleBlockGraph implements BlockGraph {
         return nodesInPos.get(pos.pos()).stream()
             .filter(node -> node.getNode() instanceof SidedBlockNode sidedNode &&
                 sidedNode.getSide() == pos.side()).map(node -> node.cast(SidedBlockNode.class));
+    }
+
+    /**
+     * Gets the node holder at a specific position.
+     *
+     * @param pos the position of the node to get.
+     * @return the node holder at the given position.
+     */
+    @Override
+    public @Nullable NodeHolder<BlockNode> getNodeAt(@NotNull NodePos pos) {
+        return nodesToHolders.get(pos);
     }
 
     @Override
@@ -407,6 +419,7 @@ public class SimpleBlockGraph implements BlockGraph {
         // Ok, we did end up needing this "rebuildRefs" after all, but only under specific circumstances
         chunks.clear();
         nodesInPos.clear();
+        nodesToHolders.clear();
         nodeTypeCache.clear();
         controller.markDirty(id);
         for (var node : graph) {
@@ -414,7 +427,9 @@ public class SimpleBlockGraph implements BlockGraph {
             data.graphId = id;
             BlockPos pos = data.getPos();
             chunks.add(ChunkSectionPos.from(pos).asLong());
-            nodesInPos.put(pos, new SimpleNodeHolder<>(node));
+            NodeHolder<BlockNode> holder = new SimpleNodeHolder<>(node);
+            nodesInPos.put(pos, holder);
+            nodesToHolders.put(holder.toNodePos(), holder);
         }
     }
 
@@ -434,6 +449,7 @@ public class SimpleBlockGraph implements BlockGraph {
         }
 
         nodesInPos.put(pos, graphNode);
+        nodesToHolders.put(nodePos, graphNode);
         chunks.add(ChunkSectionPos.from(pos).asLong());
         nodeTypeCache.clear();
         controller.putGraphWithNode(id, nodePos);
@@ -455,6 +471,7 @@ public class SimpleBlockGraph implements BlockGraph {
         BlockPos removedPos = node.getPos();
         ChunkSectionPos removedChunk = ChunkSectionPos.from(removedPos);
         nodesInPos.remove(removedPos, node);
+        nodesToHolders.remove(removedNode);
         nodeTypeCache.clear();
         controller.markDirty(id);
 
@@ -532,13 +549,13 @@ public class SimpleBlockGraph implements BlockGraph {
     }
 
     void link(@NotNull NodeHolder<BlockNode> a, @NotNull NodeHolder<BlockNode> b, LinkKey key,
-              @NotNull Function<LinkEntityContext, @Nullable LinkEntity> entityFactory) {
+              @NotNull LinkEntityFactory entityFactory) {
         LinkHolder<LinkKey> link = new SimpleLinkHolder<>(
             graph.link(((SimpleNodeHolder<BlockNode>) a).node, ((SimpleNodeHolder<BlockNode>) b).node, key));
 
         LinkEntity linkEntity = null;
         if (key.shouldHaveLinkEntity(new LinkContext(link, controller.world, controller))) {
-            linkEntity = entityFactory.apply(new SimpleLinkEntityContext(link, controller.world, controller));
+            linkEntity = entityFactory.createNew(new SimpleLinkEntityContext(link, controller.world, controller));
         }
         if (linkEntity != null) {
             linkEntities.put(link.toLinkPos(), linkEntity);
@@ -589,6 +606,7 @@ public class SimpleBlockGraph implements BlockGraph {
         nodeEntities.putAll(other.nodeEntities);
         linkEntities.putAll(other.linkEntities);
         nodesInPos.putAll(other.nodesInPos);
+        nodesToHolders.putAll(other.nodesToHolders);
         chunks.addAll(other.chunks);
         nodeTypeCache.clear();
         controller.markDirty(id);
@@ -620,12 +638,14 @@ public class SimpleBlockGraph implements BlockGraph {
             for (Graph<SimpleNodeWrapper, LinkKey> graph : newGraphs) {
                 for (var node : graph) {
                     BlockPos pos = node.data().getPos();
-                    removedNodes.add(new NodePos(pos, node.data().getNode()));
+                    NodePos nodePos = new NodePos(pos, node.data().getNode());
+                    removedNodes.add(nodePos);
                     removedPoses.add(pos);
                     removedChunks.add(ChunkSectionPos.from(pos).asLong());
 
                     // the node is in a new graph, so it obviously isn't in our graph anymore
                     nodesInPos.remove(pos, new SimpleNodeHolder<>(node));
+                    nodesToHolders.remove(nodePos);
                 }
             }
 

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleBlockGraphChunk.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleBlockGraphChunk.java
@@ -155,7 +155,7 @@ public class SimpleBlockGraphChunk implements StorageChunk {
         nbt.put("inPos", inPosList);
     }
 
-    public void putGraphWithNode(long id, @NotNull NodePos key, Long2ObjectFunction<BlockGraph> graphGetter) {
+    public void putGraphWithNode(long id, @NotNull NodePos key, Long2ObjectFunction<SimpleBlockGraph> graphGetter) {
         markDirty.run();
 
         short posShort = ChunkSectionPos.packLocal(key.pos());
@@ -195,7 +195,7 @@ public class SimpleBlockGraphChunk implements StorageChunk {
         }
     }
 
-    public @Nullable BlockGraph getGraphForNode(NodePos key, Long2ObjectFunction<BlockGraph> graphGetter) {
+    public @Nullable SimpleBlockGraph getGraphForNode(NodePos key, Long2ObjectFunction<SimpleBlockGraph> graphGetter) {
         Short2ObjectMap<Object2LongMap<BlockNode>> nodes = getGraphNodes(graphGetter);
 
         Object2LongMap<BlockNode> uNodes = nodes.get(ChunkSectionPos.packLocal(key.pos()));
@@ -205,7 +205,7 @@ public class SimpleBlockGraphChunk implements StorageChunk {
         return graphGetter.get(uNodes.getLong(key));
     }
 
-    public boolean containsNode(NodePos key, Long2ObjectFunction<BlockGraph> graphGetter) {
+    public boolean containsNode(NodePos key, Long2ObjectFunction<SimpleBlockGraph> graphGetter) {
         Short2ObjectMap<Object2LongMap<BlockNode>> nodes = getGraphNodes(graphGetter);
 
         Object2LongMap<BlockNode> uNodes = nodes.get(ChunkSectionPos.packLocal(key.pos()));
@@ -252,7 +252,7 @@ public class SimpleBlockGraphChunk implements StorageChunk {
     }
 
     private @NotNull Short2ObjectMap<Object2LongMap<BlockNode>> getGraphNodes(
-        Long2ObjectFunction<BlockGraph> graphGetter) {
+        Long2ObjectFunction<SimpleBlockGraph> graphGetter) {
         if (blockNodes == null) {
             blockNodes = new Short2ObjectLinkedOpenHashMap<>();
 
@@ -261,7 +261,7 @@ public class SimpleBlockGraphChunk implements StorageChunk {
         return blockNodes;
     }
 
-    private void rebuildGraphNodes(Long2ObjectFunction<BlockGraph> graphGetter) {
+    private void rebuildGraphNodes(Long2ObjectFunction<SimpleBlockGraph> graphGetter) {
         // Should only be called when it is known that blockNodes != null
         assert blockNodes != null;
 


### PR DESCRIPTION
# This PR
This PR adds the ability to manually link two nodes and to specify that the link should not be removed when the nodes update their connections.

This also adds more utility methods for viewing and managing links.

# Associated Issues

* This closes #30.