### PR TITLE
Add Cache Categories

### DIFF
--- a/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/BlockGraph.java
@@ -1,5 +1,6 @@
 package com.kneelawk.graphlib.api.graph;
 
+import java.util.Collection;
 import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
@@ -15,6 +16,7 @@ import com.kneelawk.graphlib.api.graph.user.LinkEntity;
 import com.kneelawk.graphlib.api.graph.user.LinkKey;
 import com.kneelawk.graphlib.api.graph.user.NodeEntity;
 import com.kneelawk.graphlib.api.graph.user.SidedBlockNode;
+import com.kneelawk.graphlib.api.util.CacheCategory;
 import com.kneelawk.graphlib.api.util.LinkPos;
 import com.kneelawk.graphlib.api.util.NodePos;
 import com.kneelawk.graphlib.api.util.SidedPos;
@@ -102,13 +104,13 @@ public interface BlockGraph {
     @NotNull Stream<NodeHolder<BlockNode>> getNodes();
 
     /**
-     * Gets all nodes in this graph with the given type.
+     * Gets all nodes in this graph that match the given cache category.
      *
-     * @param type the type that all returned nodes must be.
-     * @param <T>  the type of the nodes we're searching for.
-     * @return a stream of all the nodes in this graph with the given type.
+     * @param category the category of the cache to retrieve.
+     * @param <T>      the type of node being retrieved.
+     * @return all nodes in this graph that match the given cache category.
      */
-    @NotNull <T extends BlockNode> Stream<NodeHolder<T>> getNodesOfType(@NotNull Class<T> type);
+    @NotNull <T extends BlockNode> Collection<NodeHolder<T>> getCachedNodes(@NotNull CacheCategory<T> category);
 
     /**
      * Gets all the chunk sections that this graph currently has nodes in.

--- a/src/main/java/com/kneelawk/graphlib/api/graph/GraphUniverse.java
+++ b/src/main/java/com/kneelawk/graphlib/api/graph/GraphUniverse.java
@@ -22,6 +22,7 @@ import com.kneelawk.graphlib.api.graph.user.LinkKey;
 import com.kneelawk.graphlib.api.graph.user.LinkKeyDecoder;
 import com.kneelawk.graphlib.api.graph.user.NodeEntity;
 import com.kneelawk.graphlib.api.graph.user.NodeEntityDecoder;
+import com.kneelawk.graphlib.api.util.CacheCategory;
 import com.kneelawk.graphlib.api.world.SaveMode;
 import com.kneelawk.graphlib.impl.graph.simple.SimpleGraphUniverseBuilder;
 
@@ -272,6 +273,42 @@ public interface GraphUniverse {
      * @return all the graph entity types currently registered.
      */
     @NotNull Iterable<GraphEntityType<?>> getAllGraphEntityTypes();
+
+    /**
+     * Registers a cache category to be auto-initialized on all graphs.
+     *
+     * @param category the category to be registered.
+     */
+    void addCacheCategory(@NotNull CacheCategory<?> category);
+
+    /**
+     * Registers a set of cache categories to be auto-initialized on all graphs.
+     *
+     * @param categories the categories to be registered.
+     */
+    default void addCacheCategories(@NotNull CacheCategory<?>... categories) {
+        for (CacheCategory<?> category : categories) {
+            addCacheCategory(category);
+        }
+    }
+
+    /**
+     * Registers a set of cache categories to be auto-initialized on all graphs.
+     *
+     * @param categories the categories to be registered.
+     */
+    default void addCacheCategories(@NotNull Iterable<CacheCategory<?>> categories) {
+        for (CacheCategory<?> category : categories) {
+            addCacheCategory(category);
+        }
+    }
+
+    /**
+     * Gets all the cache categories currently registered.
+     *
+     * @return all cache categories currently registered.
+     */
+    @NotNull Iterable<CacheCategory<?>> getCacheCatetories();
 
     /**
      * Registers this graph universe so that it can be found by its id.

--- a/src/main/java/com/kneelawk/graphlib/api/util/CacheCategory.java
+++ b/src/main/java/com/kneelawk/graphlib/api/util/CacheCategory.java
@@ -1,0 +1,87 @@
+package com.kneelawk.graphlib.api.util;
+
+import java.util.function.Predicate;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.kneelawk.graphlib.api.graph.NodeHolder;
+import com.kneelawk.graphlib.api.graph.user.BlockNode;
+
+/**
+ * Acts as both key and predicate for graphs' filtered node caches.
+ * <p>
+ * Note: cache categories should be kept around and re-used. Caching does not work if a new cache category is created
+ * every time a lookup is needed.
+ *
+ * @param <T> the type of node this category operates on.
+ */
+public class CacheCategory<T extends BlockNode> {
+    private final Class<T> nodeClass;
+    private final Predicate<NodeHolder<T>> predicate;
+
+    private CacheCategory(Class<T> nodeClass, Predicate<NodeHolder<T>> predicate) {
+        this.nodeClass = nodeClass;
+        this.predicate = predicate;
+    }
+
+    /**
+     * Gets the class of the nodes this filters for.
+     *
+     * @return the class of the nodes this filters for.
+     */
+    public @NotNull Class<T> getNodeClass() {
+        return nodeClass;
+    }
+
+    /**
+     * Checks whether a given node holder matches this cache category.
+     *
+     * @param holder the node holder to check.
+     * @return <code>true</code> if the given node holder should be included in this category's cache.
+     */
+    public boolean matches(@NotNull NodeHolder<?> holder) {
+        return holder.canCast(nodeClass) && predicate.test(holder.cast(nodeClass));
+    }
+
+    /**
+     * Creates a new cache category.
+     * <p>
+     * Note: cache categories should be kept around and re-used. Caching does not work if a new cache category is created
+     * every time a lookup is needed.
+     *
+     * @param nodeClass the class of node the associated caches store.
+     * @param predicate the filter that all nodes in the associated caches match.
+     * @param <T>       the type of node in this cache category.
+     * @return a new cache category.
+     */
+    public static <T extends BlockNode> CacheCategory<T> of(Class<T> nodeClass, Predicate<NodeHolder<T>> predicate) {
+        return new CacheCategory<>(nodeClass, predicate);
+    }
+
+    /**
+     * Creates a new cache category, with only a type as its filter.
+     * <p>
+     * Note: cache categories should be kept around and re-used. Caching does not work if a new cache category is created
+     * every time a lookup is needed.
+     *
+     * @param nodeClass the class of node to filter by.
+     * @param <T>       the type of node in this cache category.
+     * @return a new cache category.
+     */
+    public static <T extends BlockNode> CacheCategory<T> of(Class<T> nodeClass) {
+        return new CacheCategory<>(nodeClass, holder -> true);
+    }
+
+    /**
+     * Creates a new cache category, with only a predicate as its filter.
+     * <p>
+     * Note: cache categories should be kept around and re-used. Caching does not work if a new cache category is created
+     * every time a lookup is needed.
+     *
+     * @param predicate the filter that all nodes in the associated caches match.
+     * @return a new cache category.
+     */
+    public static CacheCategory<BlockNode> of(Predicate<NodeHolder<BlockNode>> predicate) {
+        return new CacheCategory<>(BlockNode.class, predicate);
+    }
+}

--- a/src/main/java/com/kneelawk/graphlib/api/util/CacheCategory.java
+++ b/src/main/java/com/kneelawk/graphlib/api/util/CacheCategory.java
@@ -2,6 +2,7 @@ package com.kneelawk.graphlib.api.util;
 
 import java.util.function.Predicate;
 
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import com.kneelawk.graphlib.api.graph.NodeHolder;
@@ -54,7 +55,8 @@ public class CacheCategory<T extends BlockNode> {
      * @param <T>       the type of node in this cache category.
      * @return a new cache category.
      */
-    public static <T extends BlockNode> CacheCategory<T> of(Class<T> nodeClass, Predicate<NodeHolder<T>> predicate) {
+    @Contract(value = "_, _ -> new", pure = true)
+    public static <T extends BlockNode> @NotNull CacheCategory<T> of(Class<T> nodeClass, Predicate<NodeHolder<T>> predicate) {
         return new CacheCategory<>(nodeClass, predicate);
     }
 
@@ -68,7 +70,8 @@ public class CacheCategory<T extends BlockNode> {
      * @param <T>       the type of node in this cache category.
      * @return a new cache category.
      */
-    public static <T extends BlockNode> CacheCategory<T> of(Class<T> nodeClass) {
+    @Contract(value = "_ -> new", pure = true)
+    public static <T extends BlockNode> @NotNull CacheCategory<T> of(Class<T> nodeClass) {
         return new CacheCategory<>(nodeClass, holder -> true);
     }
 
@@ -81,7 +84,8 @@ public class CacheCategory<T extends BlockNode> {
      * @param predicate the filter that all nodes in the associated caches match.
      * @return a new cache category.
      */
-    public static CacheCategory<BlockNode> of(Predicate<NodeHolder<BlockNode>> predicate) {
+    @Contract(value = "_ -> new", pure = true)
+    public static @NotNull CacheCategory<BlockNode> of(Predicate<NodeHolder<BlockNode>> predicate) {
         return new CacheCategory<>(BlockNode.class, predicate);
     }
 }

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphUniverse.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleGraphUniverse.java
@@ -17,6 +17,7 @@ import org.jetbrains.annotations.Nullable;
 import it.unimi.dsi.fastutil.Pair;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
@@ -30,6 +31,7 @@ import com.kneelawk.graphlib.api.graph.user.GraphEntityType;
 import com.kneelawk.graphlib.api.graph.user.LinkEntityDecoder;
 import com.kneelawk.graphlib.api.graph.user.LinkKeyDecoder;
 import com.kneelawk.graphlib.api.graph.user.NodeEntityDecoder;
+import com.kneelawk.graphlib.api.util.CacheCategory;
 import com.kneelawk.graphlib.api.util.ColorUtils;
 import com.kneelawk.graphlib.api.util.EmptyLinkKey;
 import com.kneelawk.graphlib.api.world.SaveMode;
@@ -47,6 +49,7 @@ public class SimpleGraphUniverse implements GraphUniverse, GraphUniverseImpl {
     private final Map<Identifier, LinkKeyDecoder> linkKeyDecoders = new LinkedHashMap<>();
     private final Map<Identifier, LinkEntityDecoder> linkEntityDecoders = new LinkedHashMap<>();
     private final Map<Identifier, GraphEntityType<?>> graphEntityTypes = new LinkedHashMap<>();
+    private final Set<CacheCategory<?>> cacheCategories = new ObjectLinkedOpenHashSet<>();
     final SaveMode saveMode;
 
     public SimpleGraphUniverse(Identifier universeId, SimpleGraphUniverseBuilder builder) {
@@ -183,6 +186,16 @@ public class SimpleGraphUniverse implements GraphUniverse, GraphUniverseImpl {
         for (GraphEntityType<?> type : types) {
             this.graphEntityTypes.put(type.id(), type);
         }
+    }
+
+    @Override
+    public void addCacheCategory(@NotNull CacheCategory<?> category) {
+        cacheCategories.add(category);
+    }
+
+    @Override
+    public @NotNull Iterable<CacheCategory<?>> getCacheCatetories() {
+        return cacheCategories;
     }
 
     @Override


### PR DESCRIPTION
# This PR
This adds `CacheCategory`s that are used for caching filtered sets of nodes in graphs. Cache categories can be registered to be auto-cached when a graph is updated, or they can be calculated just-in-time.

# Associated Issues
* This closes #25.