### PR TITLE
Bring BlanketCon Fixes to Main

### DIFF
--- a/src/main/java/com/kneelawk/graphlib/api/world/UnloadingRegionBasedStorage.java
+++ b/src/main/java/com/kneelawk/graphlib/api/world/UnloadingRegionBasedStorage.java
@@ -188,13 +188,16 @@ public class UnloadingRegionBasedStorage<R extends StorageChunk> implements Regi
             // try and load the pillar
             return worker.readChunkData(chunkPos).thenAcceptAsync(root -> {
                 try {
-                    if (root.isPresent()) {
-                        timer.onChunkUse(chunkPos);
-                        Int2ObjectMap<R> pillar = new Int2ObjectOpenHashMap<>();
-                        loadChunkPillar(chunkPos, pillar, root.get());
-                    } else {
-                        timer.onChunkUse(chunkPos);
-                        loadedChunks.put(chunkPos.toLong(), new Int2ObjectOpenHashMap<>());
+                    // double check that the chunk hasn't already been loaded
+                    if (!loadedChunks.containsKey(chunkPos.toLong())) {
+                        if (root.isPresent()) {
+                            timer.onChunkUse(chunkPos);
+                            Int2ObjectMap<R> pillar = new Int2ObjectOpenHashMap<>();
+                            loadChunkPillar(chunkPos, pillar, root.get());
+                        } else {
+                            timer.onChunkUse(chunkPos);
+                            loadedChunks.put(chunkPos.toLong(), new Int2ObjectOpenHashMap<>());
+                        }
                     }
                 } catch (Exception e) {
                     GLLog.error("Error loading chunk pillar {}.", chunkPos, e);

--- a/src/main/java/com/kneelawk/graphlib/api/world/UnloadingRegionBasedStorage.java
+++ b/src/main/java/com/kneelawk/graphlib/api/world/UnloadingRegionBasedStorage.java
@@ -3,6 +3,7 @@ package com.kneelawk.graphlib.api.world;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -182,23 +183,25 @@ public class UnloadingRegionBasedStorage<R extends StorageChunk> implements Regi
         }
     }
 
-    private void loadChunkPillar(@NotNull ChunkPos chunkPos) {
+    private CompletableFuture<Void> loadChunkPillar(@NotNull ChunkPos chunkPos) {
         if (!loadedChunks.containsKey(chunkPos.toLong())) {
             // try and load the pillar
-            try {
-                Optional<NbtCompound> root = worker.readChunkData(chunkPos).join();
-                if (root.isPresent()) {
-                    timer.onChunkUse(chunkPos);
-                    Int2ObjectMap<R> pillar = new Int2ObjectOpenHashMap<>();
-                    loadChunkPillar(chunkPos, pillar, root.get());
-                } else {
-                    timer.onChunkUse(chunkPos);
-                    loadedChunks.put(chunkPos.toLong(), new Int2ObjectOpenHashMap<>());
+            return worker.readChunkData(chunkPos).thenAccept(root -> {
+                try {
+                    if (root.isPresent()) {
+                        timer.onChunkUse(chunkPos);
+                        Int2ObjectMap<R> pillar = new Int2ObjectOpenHashMap<>();
+                        loadChunkPillar(chunkPos, pillar, root.get());
+                    } else {
+                        timer.onChunkUse(chunkPos);
+                        loadedChunks.put(chunkPos.toLong(), new Int2ObjectOpenHashMap<>());
+                    }
+                } catch (Exception e) {
+                    GLLog.error("Error loading chunk pillar {}.", chunkPos, e);
                 }
-            } catch (Exception e) {
-                GLLog.error("Error loading chunk pillar {}.", chunkPos, e);
-            }
+            });
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     private void loadChunkPillar(@NotNull ChunkPos chunkPos, @NotNull Int2ObjectMap<R> pillar,

--- a/src/main/java/com/kneelawk/graphlib/api/world/UnloadingRegionBasedStorage.java
+++ b/src/main/java/com/kneelawk/graphlib/api/world/UnloadingRegionBasedStorage.java
@@ -186,7 +186,7 @@ public class UnloadingRegionBasedStorage<R extends StorageChunk> implements Regi
     private CompletableFuture<Void> loadChunkPillar(@NotNull ChunkPos chunkPos) {
         if (!loadedChunks.containsKey(chunkPos.toLong())) {
             // try and load the pillar
-            return worker.readChunkData(chunkPos).thenAccept(root -> {
+            return worker.readChunkData(chunkPos).thenAcceptAsync(root -> {
                 try {
                     if (root.isPresent()) {
                         timer.onChunkUse(chunkPos);
@@ -199,7 +199,7 @@ public class UnloadingRegionBasedStorage<R extends StorageChunk> implements Regi
                 } catch (Exception e) {
                     GLLog.error("Error loading chunk pillar {}.", chunkPos, e);
                 }
-            });
+            }, world.getServer());
         }
         return CompletableFuture.completedFuture(null);
     }


### PR DESCRIPTION
# This PR
This PR brings the fixes introduced during BlanketCon 2023 into the main branch.

The main issue addressed here is that, on occasion, `loadChunkPillar` would deadlock when called during a chunk load.

After these fixes were introduced, the deadlocking issue did not reoccur on the BlanketCon server.

# Associated Issues
* This fixes #50.