### PR TITLE
Add Rebuild-Chunks Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ machines.
 Sometimes a server crash can cause a block-graph to get saved without any block-nodes in it. These empty graphs can
 clutter up your save file. This command removes these empty graphs.
 
+### `/graphlib <universe> rebuildchunks <from> <to>`
+
+Sometimes a server crash can cause only graphs or only chunk-indexes to be saved but not the other, meaning that the
+index used to look up which graphs are in which positions could be out of date. This command rebuilds that index for the
+given chunks.
+
+**Note: the command arguments `<from>` and `<to>` are block-positions, not chunk positions. Running this command for one
+block in a 16x16x16 chunk section should fix the entire chunk section.**
+
 ## Depending on GraphLib
 
 GraphLib can be added to a gradle project's dependencies like such:

--- a/changelogs/changelog-v1.3.0+1.20.md
+++ b/changelogs/changelog-v1.3.0+1.20.md
@@ -1,3 +1,5 @@
 Changes:
 
 * Fixed loading graph chunks during world-chunk loading causing deadlocks.
+* Added `/graphlib <universe-id> rebuildchunks <from-x> <from-y> <from-z> <to-x> <to-y> <to-z>` command for rebuilding
+  chunk graph indices if they get corrupted by a server crash.

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ quilt_mappings = 4
 fabric_loader_version = 0.14.21
 
 # Mod Properties
-mod_version = 1.0.0-alpha.99+1.20.local
+mod_version = 1.99.99+1.20.local
 maven_group = com.kneelawk
 archives_base_name = graphlib
 

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/RebuildChunksCallbacks.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/RebuildChunksCallbacks.java
@@ -1,0 +1,31 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Kneelawk.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+package com.kneelawk.graphlib.impl.graph;
+
+public interface RebuildChunksCallbacks {
+    // Note to self:
+    // Rebuilding chunks should apply graphs in reverse-id order.
+}

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/RebuildChunksListener.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/RebuildChunksListener.java
@@ -25,7 +25,12 @@
 
 package com.kneelawk.graphlib.impl.graph;
 
-public interface RebuildChunksCallbacks {
-    // Note to self:
-    // Rebuilding chunks should apply graphs in reverse-id order.
+public interface RebuildChunksListener {
+    void onAlreadyRunning(double progress, int graphCount, int chunkCount);
+
+    void onBegin(int graphCount, int chunkCount);
+
+    void onProgress(double progress, int graphCount, int chunkCount);
+
+    void onComplete(int graphCount, int chunkCount);
 }

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/ServerGraphWorldImpl.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/ServerGraphWorldImpl.java
@@ -1,9 +1,12 @@
 package com.kneelawk.graphlib.impl.graph;
 
+import java.util.List;
+
 import org.jetbrains.annotations.NotNull;
 
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.ChunkSectionPos;
 
 import alexiil.mc.lib.net.IMsgWriteCtx;
 import alexiil.mc.lib.net.NetByteBuf;
@@ -36,6 +39,14 @@ public interface ServerGraphWorldImpl extends GraphWorld, AutoCloseable {
      * @return the number of empty graphs removed.
      */
     int removeEmptyGraphs();
+
+    /**
+     * Starts a chunk rebuilding task.
+     *
+     * @param toRebuild the chunks to rebuild.
+     * @param listener  progress and completion listeners.
+     */
+    void rebuildChunks(List<ChunkSectionPos> toRebuild, RebuildChunksListener listener);
 
     @Override
     @NotNull ServerWorld getWorld();

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleBlockGraphChunk.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleBlockGraphChunk.java
@@ -155,6 +155,16 @@ public class SimpleBlockGraphChunk implements StorageChunk {
         nbt.put("inPos", inPosList);
     }
 
+    public void clear() {
+        graphsInPos.clear();
+        graphsInChunk.clear();
+        if (blockNodes == null) {
+            blockNodes = new Short2ObjectLinkedOpenHashMap<>();
+        } else {
+            blockNodes.clear();
+        }
+    }
+
     public void putGraphWithNode(long id, @NotNull NodePos key, Long2ObjectFunction<SimpleBlockGraph> graphGetter) {
         markDirty.run();
 

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleServerGraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleServerGraphWorld.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.Nullable;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.LongBidirectionalIterator;
 import it.unimi.dsi.fastutil.longs.LongIterable;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
@@ -69,6 +70,7 @@ import com.kneelawk.graphlib.api.world.SaveMode;
 import com.kneelawk.graphlib.api.world.UnloadingRegionBasedStorage;
 import com.kneelawk.graphlib.impl.Constants;
 import com.kneelawk.graphlib.impl.GLLog;
+import com.kneelawk.graphlib.impl.graph.RebuildChunksListener;
 import com.kneelawk.graphlib.impl.graph.ServerGraphWorldImpl;
 import com.kneelawk.graphlib.impl.net.GLNet;
 
@@ -85,6 +87,11 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
      */
     private static final int MAX_AGE = 20 * 60;
     private static final int INCREMENTAL_SAVE_FACTOR = 10;
+
+    /**
+     * The maximum number of graphs to re-add to chunks each tick during a chunk rebuild.
+     */
+    private static final int MAX_GRAPHS_REBUILT_PER_TICK = 100;
 
     final SimpleGraphUniverse universe;
 
@@ -109,6 +116,8 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
 
     private boolean stateDirty = false;
     private long prevGraphId = -1L;
+
+    private ChunkRebuildState rebuildState = null;
 
     private boolean closed = false;
 
@@ -158,6 +167,8 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
 
     @Override
     public void tick() {
+        continueRebuildingChunks();
+
         chunks.tick();
         timer.tick();
 
@@ -686,6 +697,7 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
 
                 if (aHolder == null) {
                     GLLog.warn("Chunk has reference to node {} but the referenced graph does not have that node!", a);
+                    logRebuildChunksSuggestion(a.pos());
 
                     // the graph merge was faulty
                     mergedGraph.split();
@@ -693,6 +705,7 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
                 }
                 if (bHolder == null) {
                     GLLog.warn("Chunk has reference to node {} but the referenced graph does not have that node!", b);
+                    logRebuildChunksSuggestion(b.pos());
 
                     // the graph merge was faulty
                     mergedGraph.split();
@@ -727,6 +740,7 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
                 NodeHolder<BlockNode> aHolder = graph.getNodeAt(a);
                 if (aHolder == null) {
                     GLLog.warn("Chunk has reference to node {} but the referenced graph does not have that node!", a);
+                    logRebuildChunksSuggestion(a.pos());
                     return false;
                 }
                 NodeHolder<BlockNode> bHolder = graph.getNodeAt(b);
@@ -947,6 +961,44 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
         return removed;
     }
 
+    /**
+     * Starts a chunk rebuilding task.
+     *
+     * @param toRebuild the chunks to rebuild.
+     * @param listener  progress and completion listeners.
+     */
+    @Override
+    public void rebuildChunks(List<ChunkSectionPos> toRebuild, RebuildChunksListener listener) {
+        if (rebuildState == null) {
+            LongSet chunksToRebuild = new LongLinkedOpenHashSet();
+            for (ChunkSectionPos pos : toRebuild) {
+                chunksToRebuild.add(pos.asLong());
+                SimpleBlockGraphChunk chunk = chunks.getIfExists(pos);
+                if (chunk != null) {
+                    chunk.clear();
+                }
+            }
+
+            LongSortedSet existingGraphs = getExistingGraphs();
+
+            listener.onBegin(existingGraphs.size(), chunksToRebuild.size());
+
+            long lastGraph = rebuildSomeGraphs(existingGraphs, chunksToRebuild);
+
+            if (lastGraph == existingGraphs.firstLong()) {
+                listener.onComplete(existingGraphs.size(), chunksToRebuild.size());
+            } else {
+                rebuildState = new ChunkRebuildState(chunksToRebuild, listener, existingGraphs.lastLong(), lastGraph,
+                    existingGraphs.size());
+            }
+        } else {
+            double progress = 1.0 - (((double) rebuildState.lastGraph) / ((double) rebuildState.firstGraph));
+
+            rebuildState.listener.onAlreadyRunning(progress, rebuildState.approximateGraphCount,
+                rebuildState.toRebuild.size());
+        }
+    }
+
     // ---- Internal Methods ---- //
 
     @Override
@@ -1144,6 +1196,7 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
             if (graph == null) {
                 GLLog.warn("Encountered invalid graph in position when detecting node changes. Id: {}, pos: {}",
                     graphId, pos);
+                logRebuildChunksSuggestion(pos);
                 continue;
             }
 
@@ -1259,6 +1312,80 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
         }
     }
 
+    private void continueRebuildingChunks() {
+        if (rebuildState != null) {
+            LongSortedSet existingGraphs = getExistingGraphs();
+            rebuildState.approximateGraphCount = existingGraphs.size();
+
+            LongSortedSet nextGraphs = existingGraphs.headSet(rebuildState.lastGraph);
+
+            long lastGraph = rebuildSomeGraphs(nextGraphs, rebuildState.toRebuild);
+
+            if (lastGraph == nextGraphs.firstLong()) {
+                rebuildState.listener.onComplete(existingGraphs.size(), rebuildState.toRebuild.size());
+                rebuildState = null;
+            } else {
+                rebuildState.lastGraph = lastGraph;
+
+                if (++rebuildState.ticksSinceLastProgressReport >= 20) {
+                    double progress = 1.0 - (((double) lastGraph) / ((double) rebuildState.firstGraph));
+
+                    rebuildState.listener.onProgress(progress, rebuildState.approximateGraphCount,
+                        rebuildState.toRebuild.size());
+                }
+            }
+        }
+    }
+
+    private long rebuildSomeGraphs(LongSortedSet graphIds, LongSet chunks) {
+        LongBidirectionalIterator iter = graphIds.iterator();
+        int rebuiltCount = 0;
+        long rebuild = graphIds.firstLong();
+
+        while (rebuiltCount < MAX_GRAPHS_REBUILT_PER_TICK && iter.hasPrevious()) {
+            rebuild = iter.previousLong();
+
+            reAddGraphToChunks(rebuild, chunks);
+
+            rebuiltCount++;
+        }
+
+        return rebuild;
+    }
+
+    /**
+     * Re-adds a graph to all the chunks it is in that are contained in the given set.
+     * <p>
+     * This is intended to be called during chunk rebuilds.
+     *
+     * @param graphId    the id of the graph to re-add.
+     * @param chunkPoses the chunks that graphs are to be re-added to.
+     */
+    private void reAddGraphToChunks(long graphId, LongSet chunkPoses) {
+        SimpleBlockGraph graph = loadedGraphs.get(graphId);
+        
+        if (graph == null) {
+            graph = readGraph(graphId);
+        }
+
+        if (graph == null) return;
+
+        Iterator<NodeHolder<BlockNode>> holderIterator = graph.getNodes().iterator();
+        while (holderIterator.hasNext()) {
+            NodeHolder<BlockNode> holder = holderIterator.next();
+            ChunkSectionPos sectionPos = ChunkSectionPos.from(holder.getBlockPos());
+
+            if (chunkPoses.contains(sectionPos.asLong())) {
+                SimpleBlockGraphChunk chunk = chunks.getOrCreate(sectionPos);
+                chunk.putGraphWithNode(graphId, holder.getPos(), id -> {
+                    throw new AssertionError(
+                        "This chunk (" + sectionPos +
+                            ") should already have had its node->graph map initialized and should not need to rebuild it. This is a bug.");
+                });
+            }
+        }
+    }
+
     private void tickGraphs() {
         for (SimpleBlockGraph graph : loadedGraphs.values()) {
             graph.onTick();
@@ -1370,7 +1497,7 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
     private static final Pattern GRAPH_ID_PATTERN = Pattern.compile("^(?<id>[\\da-fA-F]+)\\.dat$");
 
     private @NotNull LongSortedSet getExistingGraphs() {
-        LongSortedSet ids = new LongRBTreeSet();
+        LongSortedSet ids = new LongRBTreeSet(Long::compareUnsigned);
         ids.addAll(loadedGraphs.keySet());
 
         try (Stream<Path> children = Files.list(graphsDir)) {
@@ -1519,6 +1646,11 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
         }
     }
 
+    private void logRebuildChunksSuggestion(BlockPos affected) {
+        GLLog.info("Use the command '/graphlib {} rebuildchunks {} {} {} {} {} {}' in the {} dimension to fix the issue.", universe.getId(), affected.getX(),
+            affected.getY(), affected.getZ(), affected.getX(), affected.getY(), affected.getZ(), world.getRegistryKey().getValue());
+    }
+
     private sealed interface UpdatePos {}
 
     private record UpdateBlockPos(BlockPos pos) implements UpdatePos {}
@@ -1526,4 +1658,22 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
     private record UpdateSidedPos(SidedPos pos) implements UpdatePos {}
 
     private record CallbackUpdate(NodeHolder<BlockNode> holder, boolean validate) {}
+
+    private static class ChunkRebuildState {
+        final LongSet toRebuild;
+        final RebuildChunksListener listener;
+        final long firstGraph;
+        long lastGraph;
+        int approximateGraphCount;
+        int ticksSinceLastProgressReport = 0;
+
+        ChunkRebuildState(LongSet toRebuild, RebuildChunksListener listener, long firstGraph,
+                          long lastGraph, int approximateGraphCount) {
+            this.toRebuild = toRebuild;
+            this.listener = listener;
+            this.firstGraph = firstGraph;
+            this.lastGraph = lastGraph;
+            this.approximateGraphCount = approximateGraphCount;
+        }
+    }
 }

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleServerGraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleServerGraphWorld.java
@@ -1197,6 +1197,7 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
 
     private void onNodesChanged(@NotNull BlockPos pos, @NotNull Set<BlockNode> nodes) {
         Set<BlockNode> newNodes = new LinkedHashSet<>(nodes);
+        Set<BlockNode> existingNodes = new LinkedHashSet<>();
 
         for (long graphId : getAllGraphIdsAt(pos).toArray()) {
             SimpleBlockGraph graph = getGraph(graphId);
@@ -1211,8 +1212,12 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
                 BlockNode bn = node.getNode();
                 if (bn.isAutomaticRemoval(node) && !nodes.contains(bn)) {
                     graph.destroyNode(node, true);
+                } else if (existingNodes.contains(bn)) {
+                    GLLog.warn("Duplicate nodes {} found at {}. Removing...", bn, pos);
+                    graph.destroyNode(node, true);
                 }
                 newNodes.remove(bn);
+                existingNodes.add(bn);
             }
         }
 

--- a/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleServerGraphWorld.java
+++ b/src/main/java/com/kneelawk/graphlib/impl/graph/simple/SimpleServerGraphWorld.java
@@ -24,13 +24,13 @@ import org.jetbrains.annotations.Nullable;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongIterable;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongLinkedOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongRBTreeSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongSortedSet;
 import it.unimi.dsi.fastutil.objects.Object2IntLinkedOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
@@ -1369,8 +1369,8 @@ public class SimpleServerGraphWorld implements AutoCloseable, GraphWorld, Server
 
     private static final Pattern GRAPH_ID_PATTERN = Pattern.compile("^(?<id>[\\da-fA-F]+)\\.dat$");
 
-    private @NotNull LongList getExistingGraphs() {
-        LongList ids = new LongArrayList();
+    private @NotNull LongSortedSet getExistingGraphs() {
+        LongSortedSet ids = new LongRBTreeSet();
         ids.addAll(loadedGraphs.keySet());
 
         try (Stream<Path> children = Files.list(graphsDir)) {

--- a/src/main/resources/assets/graphlib/lang/en_us.json
+++ b/src/main/resources/assets/graphlib/lang/en_us.json
@@ -1,5 +1,9 @@
 {
   "command.graphlib.graphlib.updateblocks.starting": "Updating GraphLib block-nodes from %s to %s... This could cause some lag.",
   "command.graphlib.graphlib.updateblocks.success": "Finished updating GraphLib block-nodes from %s to %s.",
-  "command.graphlib.graphlib.removeemptygraphs.success": "Removed %d empty graphs."
+  "command.graphlib.graphlib.removeemptygraphs.success": "Removed %d empty graphs.",
+  "command.graphlib.graphlib.rebuildchunks.begin": "Rebuilding %s chunks with %d graphs over section (%d, %d, %d) to section (%d, %d, %d) (%d chunks).",
+  "command.graphlib.graphlib.rebuildchunks.progress": "%s%% complete. Rebuilding %s chunks with %d graphs over section (%d, %d, %d) to section (%d, %d, %d) (%d chunks).",
+  "command.graphlib.graphlib.rebuildchunks.complete": "Finished rebuilding %s chunks with %d graphs over section (%d, %d, %d) to section (%d, %d, %d) (%d chunks).",
+  "command.graphlib.graphlib.rebuildchunks.alreadyrunning": "Chunk rebuild already running. %s%% complete. Rebuilding %s chunks with %d graphs over section (%d, %d, %d) to section (%d, %d, %d) (%d chunks)."
 }


### PR DESCRIPTION
# This PR
This PR adds a `rebuildchunks` subcommand to the `/graphlib` command. This rebuild-chunks command clears the graph indexes for the given chunks and then re-indexes all graphs in the given world for the given chunks. Care is taken to spread this operation across multiple server ticks so as to not halt the server thread while this processing is taking place.

While testing it also became clear that duplicate nodes were not properly dealt with. Some extra logic was added to the node-change-detection to properly remove duplicate nodes.

# Associated Issues
* This fixes #46.